### PR TITLE
feat(#7): Dev-Standards Baseline + Sync/Ruleset Scripts (Teil 1)

### DIFF
--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -36,28 +36,43 @@ jobs:
 
           findings=0
 
+          # git grep: exit 0 = Match (Fund), 1 = kein Match (sauber), >=2 = echter Fehler.
+          # Echte Fehler brechen hart ab (fail-closed), statt als "keine" durchzurutschen.
+          grep_scan() { # $1=Titel  $2..=git-grep-Argumente
+            local title="$1"; shift
+            local out rc
+            out="$(git grep "$@" 2>&1)"; rc=$?
+            if [ "$rc" -eq 0 ]; then
+              echo "::error title=$title::Fund im Repo"
+              printf '%s\n' "$out"
+              findings=1
+            elif [ "$rc" -eq 1 ]; then
+              echo "keine"
+            else
+              echo "::error title=Scanner-Fehler::git grep brach ab (rc=$rc) bei: $title"
+              printf '%s\n' "$out"
+              exit "$rc"
+            fi
+          }
+
           echo "::group::Signing fingerprints (SHA1/SHA256 colon-hex)"
-          if git grep -nE '([0-9A-Fa-f]{2}:){15,}[0-9A-Fa-f]{2}' -- . ':!*.lock' ':!**/node_modules/**'; then
-            echo "::error title=Signing fingerprint::Fingerprint im Repo gefunden (Issue #276)"
-            findings=1
-          else
-            echo "keine"
-          fi
+          grep_scan "Signing fingerprint" \
+            -nE '([0-9A-Fa-f]{2}:){15,}[0-9A-Fa-f]{2}' -- . ':!*.lock' ':!**/node_modules/**'
           echo "::endgroup::"
 
           echo "::group::Hardcoded API keys / tokens"
-          if git grep -niE '(api[_-]?key|secret[_-]?key|auth[_-]?token|access[_-]?token)["'\'' ]*[:=]["'\'' ]*[A-Za-z0-9_-]{16,}' \
-               -- . ':!*.lock' ':!**/node_modules/**' ':!**/*.test.*' ':!**/__tests__/**'; then
-            echo "::error title=Hardcoded secret::API-Key/Token im Code gefunden"
-            findings=1
-          else
-            echo "keine"
-          fi
+          grep_scan "Hardcoded secret" \
+            -niE '(api[_-]?key|secret[_-]?key|auth[_-]?token|access[_-]?token)["'\'' ]*[:=]["'\'' ]*[A-Za-z0-9_-]{16,}' \
+            -- . ':!*.lock' ':!**/node_modules/**' ':!**/*.test.*' ':!**/__tests__/**'
           echo "::endgroup::"
 
           echo "::group::Tracked sensitive files"
-          if git ls-files | grep -E '(credentials\.json$|\.jks$|\.keystore$|\.p12$|\.p8$)'; then
+          # git ls-files kann nicht "Fehler vs. kein Treffer" über Exit-Code liefern →
+          # Treffer über nicht-leere Ausgabe erkennen; grep-Fehler werden ignoriert (rc egal).
+          sensitive="$(git ls-files | grep -E '(credentials\.json$|\.jks$|\.keystore$|\.p12$|\.p8$)' || true)"
+          if [ -n "$sensitive" ]; then
             echo "::error title=Sensitive file tracked::credentials/keystore im Repo getrackt"
+            printf '%s\n' "$sensitive"
             findings=1
           else
             echo "keine"

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -1,0 +1,71 @@
+name: Reusable Security Scan
+
+# Pilot-Workflow (Issue #7, Phase 2). Konsumierende Repos rufen ihn versioniert auf:
+#
+#   jobs:
+#     security:
+#       uses: S540d/project-templates/.github/workflows/reusable-security-scan.yml@v1
+#
+# WICHTIG: immer auf ein getaggtes Release (@v1) pinnen, nie @main (Issue #7, Punkt 1).
+
+on:
+  workflow_call:
+    inputs:
+      fail_on_findings:
+        description: 'Bei Funden hart fehlschlagen'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  security-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Scan tracked files (fail-closed)
+        shell: bash
+        run: |
+          # fail-closed: jeder Scanner-Fehler bricht den Job ab (Issue #7, Punkt 1).
+          # Kein 'grep || true', das echte Fehler verschluckt.
+          set -euo pipefail
+
+          findings=0
+
+          echo "::group::Signing fingerprints (SHA1/SHA256 colon-hex)"
+          if git grep -nE '([0-9A-Fa-f]{2}:){15,}[0-9A-Fa-f]{2}' -- . ':!*.lock' ':!**/node_modules/**'; then
+            echo "::error title=Signing fingerprint::Fingerprint im Repo gefunden (Issue #276)"
+            findings=1
+          else
+            echo "keine"
+          fi
+          echo "::endgroup::"
+
+          echo "::group::Hardcoded API keys / tokens"
+          if git grep -niE '(api[_-]?key|secret[_-]?key|auth[_-]?token|access[_-]?token)["'\'' ]*[:=]["'\'' ]*[A-Za-z0-9_-]{16,}' \
+               -- . ':!*.lock' ':!**/node_modules/**' ':!**/*.test.*' ':!**/__tests__/**'; then
+            echo "::error title=Hardcoded secret::API-Key/Token im Code gefunden"
+            findings=1
+          else
+            echo "keine"
+          fi
+          echo "::endgroup::"
+
+          echo "::group::Tracked sensitive files"
+          if git ls-files | grep -E '(credentials\.json$|\.jks$|\.keystore$|\.p12$|\.p8$)'; then
+            echo "::error title=Sensitive file tracked::credentials/keystore im Repo getrackt"
+            findings=1
+          else
+            echo "keine"
+          fi
+          echo "::endgroup::"
+
+          if [ "$findings" -ne 0 ] && [ "${{ inputs.fail_on_findings }}" = "true" ]; then
+            echo "Security scan failed: Funde vorhanden."
+            exit 1
+          fi
+          echo "Security scan completed."

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Backups von apply-rulesets.sh (Issue #7)
+ruleset-backups/

--- a/README.md
+++ b/README.md
@@ -148,6 +148,28 @@ Zentrale Vorlagen und Standards für alle Projekte. Diese Templates definieren B
      - Admin Bypass für Hotfixes
      - Einheitliche Rules über alle Projekte
 
+5.5 **Cross-Project Standardisierung** (NEU – Issue #7, Teil 1)
+   Zentrale Source of Truth für Dev-Standards und reproduzierbares Ausrollen.
+   - **`dev-standards/`** – kanonische Basis-Konfigurationen:
+     - `base/` – `.prettierrc.json`, `.editorconfig`, `pre-commit.base` (Security: Fingerprints/Tokens, Issue #276), `global-policy.md`
+     - `react-native/` – `eslint.config.base.mjs` (erprobte FlatConfig aus EnergyPriceGermany), `tsconfig.base.json`, `pre-commit.rn`
+     - `web/` – `eslint.config.base.mjs`, `tsconfig.base.json`, `pre-commit.web`
+   - **`scripts/sync-standards.sh`** – verteilt Commands + Prettier/EditorConfig in Projekte.
+     GLOBAL POLICY wird **idempotent** über einen Marker-Block (`<!-- GLOBAL POLICY:START/END -->`)
+     in die jeweilige `CLAUDE.md` geschrieben – **lokale CLAUDE.md-Inhalte bleiben unberührt**.
+     `--dry-run` unterstützt.
+   - **`scripts/apply-rulesets.sh`** + **`github-ruleset-protect-main-base.json`** –
+     Branch-Protection (Open-Source mit Vandalismusschutz): PR-Pflicht, kein Force-Push/Delete
+     auf main, `required_approving_review_count: 0` (Solo-Merge möglich), Admin-Bypass.
+     **`--dry-run`** + automatisches Backup bestehender Rulesets + PUT-Update statt blindem POST.
+   - **`.github/workflows/reusable-security-scan.yml`** – Pilot-Reusable-Workflow,
+     **fail-closed** (Scanner-Fehler UND Funde brechen ab). Konsumierende Repos pinnen auf `@v1`,
+     **nie `@main`**.
+
+   > Hinweis: Die leeren Platzhalter-Configs früherer Stände sind durch echte, erprobte
+   > Configs ersetzt. Das Legacy `automation-templates/.eslintrc.js` (alte `.eslintrc`-Form)
+   > ist deprecated – Source of Truth ist `dev-standards/**/eslint.config.base.mjs`.
+
 ### Deployment & Publishing
 
 6. **PUBLISHING_CHECKLIST.md**

--- a/automation-templates/.eslintrc.js
+++ b/automation-templates/.eslintrc.js
@@ -1,3 +1,6 @@
+// ⚠️ DEPRECATED (Issue #7): Legacy ESLint-Format (.eslintrc).
+// Source of Truth ist jetzt dev-standards/{react-native,web}/eslint.config.base.mjs (Flat Config, ESLint 9).
+// Diese Datei nur noch für Projekte, die ESLint 8 / Legacy-Config nutzen. Nicht erweitern.
 module.exports = {
   root: true,
   extends: [

--- a/dev-standards/base/.editorconfig
+++ b/dev-standards/base/.editorconfig
@@ -1,0 +1,20 @@
+# EditorConfig – kanonische Basis für alle Projekte (Issue #7)
+# https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{json,yml,yaml}]
+indent_size = 2
+
+[Makefile]
+indent_style = tab

--- a/dev-standards/base/.prettierrc.json
+++ b/dev-standards/base/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "printWidth": 100,
+  "arrowParens": "avoid",
+  "useTabs": false
+}

--- a/dev-standards/base/global-policy.md
+++ b/dev-standards/base/global-policy.md
@@ -1,0 +1,9 @@
+## [GLOBAL POLICY]
+
+> Automatisch synchronisiert aus project-templates (Issue #7). Nicht manuell editieren –
+> Änderungen hier werden beim nächsten Sync überschrieben. Quelle anpassen statt lokal.
+
+- PRs immer gegen `testing`, nie direkt gegen `staging` oder `main`
+- Merge auf `main` nur mit expliziter schriftlicher Freigabe
+- `--delete-branch` nur für Feature-Branches (nie staging/testing)
+- `--no-verify` nur auf explizite Bitte

--- a/dev-standards/base/pre-commit.base
+++ b/dev-standards/base/pre-commit.base
@@ -1,0 +1,37 @@
+#!/usr/bin/env sh
+# ─────────────────────────────────────────────────────────────────────────
+# Kanonischer Pre-Commit Hook – Basis-Sicherheitschecks (Issue #7)
+# Projekt-spezifische Hooks (react-native/web) source-en diese Datei.
+# Übernimmt die Security-Checks aus EnergyPriceGermany (Issue #276).
+# ─────────────────────────────────────────────────────────────────────────
+
+echo "🔒 Running base security pre-commit checks..."
+
+# Nur hinzugefügte/geänderte Zeilen prüfen (staged diff, '+'-Zeilen)
+STAGED_DIFF=$(git diff --cached --diff-filter=ACM -U0)
+
+# 1. Signing-Fingerprints (SHA1/SHA256 als Colon-Hex) blockieren
+if printf '%s\n' "$STAGED_DIFF" | grep -E '^\+' \
+    | grep -Eq '([0-9A-Fa-f]{2}:){15,}[0-9A-Fa-f]{2}'; then
+  echo "❌ ERROR: Signing fingerprint (SHA1/SHA256 colon-hex) in staged changes!"
+  echo "   Fingerprints gehören nicht ins Repo (siehe Issue #276)."
+  exit 1
+fi
+
+# 2. Hardcodierte Tokens / API-Keys in '+'-Zeilen blockieren
+if printf '%s\n' "$STAGED_DIFF" | grep -E '^\+' \
+    | grep -Eiq '(api[_-]?key|secret[_-]?key|auth[_-]?token|access[_-]?token)["'\'' ]*[:=]["'\'' ]*[A-Za-z0-9_\-]{16,}'; then
+  echo "❌ ERROR: Hardcoded API key / token in staged changes!"
+  echo "   Secrets über .env / GitHub Secrets verwalten, nie committen."
+  exit 1
+fi
+
+# 3. Sensible Dateien dürfen nicht getrackt werden
+if git diff --cached --name-only --diff-filter=A \
+    | grep -Eq '(credentials\.json$|\.jks$|\.keystore$|\.p12$|\.p8$)'; then
+  echo "❌ ERROR: Sensitive file staged (credentials/keystore)!"
+  echo "   In .gitignore aufnehmen und lokal halten."
+  exit 1
+fi
+
+echo "✅ Base security checks passed."

--- a/dev-standards/react-native/eslint.config.base.mjs
+++ b/dev-standards/react-native/eslint.config.base.mjs
@@ -1,0 +1,226 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Kanonische ESLint FlatConfig (ESLint 9) – React Native / Expo
+// Source of Truth für Issue #7. Abgeleitet aus EnergyPriceGermany (erprobt).
+// Konsumierende Projekte binden sie per Spread in ihre lokale eslint.config.mjs ein.
+// Erfordert Dev-Deps: @typescript-eslint/parser, @typescript-eslint/eslint-plugin,
+//   eslint-plugin-react, eslint-plugin-react-hooks, eslint-plugin-react-native,
+//   eslint-plugin-eslint-comments, eslint-plugin-jest, eslint-config-prettier,
+//   @eslint/compat, globals
+// ─────────────────────────────────────────────────────────────────────────
+import typescriptParser from '@typescript-eslint/parser';
+import typescriptPlugin from '@typescript-eslint/eslint-plugin';
+import reactPlugin from 'eslint-plugin-react';
+import reactHooksPlugin from 'eslint-plugin-react-hooks';
+import reactNativePlugin from 'eslint-plugin-react-native';
+import eslintCommentsPlugin from 'eslint-plugin-eslint-comments';
+import jestPlugin from 'eslint-plugin-jest';
+import prettierConfig from 'eslint-config-prettier';
+import { fixupPluginRules } from '@eslint/compat';
+import globals from 'globals';
+
+// React Native globals (from @react-native/eslint-config shared.js)
+const reactNativeGlobals = {
+  __DEV__: 'writable',
+  ErrorUtils: 'readonly',
+  FormData: 'writable',
+  XMLHttpRequest: 'readonly',
+};
+
+export default [
+  // ── Global ignores ────────────────────────────────────────────────────
+  {
+    ignores: [
+      'dist/**',
+      'node_modules/**',
+      'android/**',
+      'ios/**',
+      'web-build/**',
+      '.expo/**',
+      'coverage/**',
+      '*.config.js',
+      '*.config.mjs',
+      'babel.config.js',
+      'jest.config.js',
+      'jest.setup.js',
+      'metro.config.js',
+      '__mocks__/**',
+    ],
+  },
+
+  // ── Base config for TypeScript files ──────────────────────────────────
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    languageOptions: {
+      parser: typescriptParser,
+      parserOptions: {
+        sourceType: 'module',
+        ecmaFeatures: { jsx: true },
+      },
+      globals: {
+        ...globals.browser,
+        ...globals.es2021,
+        ...reactNativeGlobals,
+      },
+    },
+    plugins: {
+      '@typescript-eslint': typescriptPlugin,
+      'react': reactPlugin,
+      'react-hooks': reactHooksPlugin,
+      'react-native': fixupPluginRules(reactNativePlugin),
+      'eslint-comments': fixupPluginRules(eslintCommentsPlugin),
+    },
+    settings: {
+      react: { version: 'detect' },
+    },
+    rules: {
+      // ── General (from @react-native/eslint-config) ──────────────────
+      'no-cond-assign': 'warn',
+      'no-const-assign': 'error',
+      'no-control-regex': 'warn',
+      'no-debugger': 'warn',
+      'no-dupe-class-members': 'error',
+      'no-dupe-keys': 'error',
+      'no-ex-assign': 'warn',
+      'no-extra-boolean-cast': 'warn',
+      'no-func-assign': 'warn',
+      'no-invalid-regexp': 'warn',
+      'no-obj-calls': 'warn',
+      'no-regex-spaces': 'warn',
+      'no-sparse-arrays': 'warn',
+      'no-unreachable': 'error',
+      'use-isnan': 'warn',
+      'valid-typeof': 'warn',
+
+      // ── Best Practices ──────────────────────────────────────────────
+      'dot-notation': 'warn',
+      'eqeqeq': ['error', 'always'],
+      'no-alert': 'warn',
+      'no-caller': 'warn',
+      'no-div-regex': 'warn',
+      'no-eval': 'error',
+      'no-extend-native': 'warn',
+      'no-extra-bind': 'warn',
+      'no-fallthrough': 'warn',
+      'no-implied-eval': 'warn',
+      'no-labels': 'warn',
+      'no-iterator': 'warn',
+      'no-lone-blocks': 'warn',
+      'no-new': 'warn',
+      'no-new-func': 'error',
+      'no-new-wrappers': 'warn',
+      'no-octal': 'warn',
+      'no-octal-escape': 'warn',
+      'no-proto': 'warn',
+      'no-return-assign': 'warn',
+      'no-script-url': 'warn',
+      'no-self-compare': 'warn',
+      'no-sequences': 'warn',
+      'no-useless-escape': 'warn',
+      'no-void': 'warn',
+      'radix': 'warn',
+      'yoda': 'warn',
+
+      // ── Variables ───────────────────────────────────────────────────
+      'no-delete-var': 'warn',
+      'no-global-assign': 'error',
+      'no-label-var': 'warn',
+      'no-shadow': 'off', // Handled by @typescript-eslint/no-shadow
+      'no-shadow-restricted-names': 'warn',
+      'no-undef': 'off', // Handled by TypeScript
+      'no-undef-init': 'warn',
+      'no-unused-vars': 'off', // Handled by @typescript-eslint/no-unused-vars
+
+      // ── Style ───────────────────────────────────────────────────────
+      'consistent-this': 'warn',
+      'no-array-constructor': 'warn',
+      'no-empty-character-class': 'warn',
+      'no-new-object': 'warn',
+      'no-bitwise': 'warn',
+      'no-var': 'error',
+      'prefer-const': 'error',
+      'no-console': ['warn', { allow: ['warn', 'error'] }],
+
+      // ── Node.js ─────────────────────────────────────────────────────
+      'no-mixed-requires': 'warn',
+      'no-new-require': 'warn',
+      'no-path-concat': 'warn',
+      'no-restricted-modules': 'warn',
+
+      // ── TypeScript ──────────────────────────────────────────────────
+      '@typescript-eslint/no-shadow': 'warn',
+      '@typescript-eslint/no-unused-vars': ['error', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        destructuredArrayIgnorePattern: '^_',
+        caughtErrors: 'none',
+      }],
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/consistent-type-imports': ['error', {
+        prefer: 'type-imports',
+        fixStyle: 'separate-type-imports',
+      }],
+      '@typescript-eslint/no-non-null-assertion': 'error',
+
+      // ── React ───────────────────────────────────────────────────────
+      'react/display-name': 'off',
+      'react/jsx-no-comment-textnodes': 'error',
+      'react/jsx-no-duplicate-props': 'error',
+      'react/jsx-no-undef': 'error',
+      'react/jsx-uses-react': 'warn',
+      'react/jsx-uses-vars': 'warn',
+      'react/no-did-mount-set-state': 'warn',
+      'react/no-did-update-set-state': 'warn',
+      'react/no-string-refs': 'error',
+      'react/no-unstable-nested-components': 'warn',
+      'react/react-in-jsx-scope': 'off',
+      'react/self-closing-comp': 'warn',
+
+      // ── React Hooks ─────────────────────────────────────────────────
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'error',
+
+      // ── React Native ────────────────────────────────────────────────
+      'react-native/no-inline-styles': 'warn',
+
+      // ── ESLint Comments ─────────────────────────────────────────────
+      'eslint-comments/no-aggregating-enable': 'warn',
+      'eslint-comments/no-unlimited-disable': 'warn',
+      'eslint-comments/no-unused-disable': 'warn',
+      'eslint-comments/no-unused-enable': 'warn',
+    },
+  },
+
+  // ── Test files (relaxed rules) ────────────────────────────────────────
+  {
+    files: ['**/__tests__/**', '**/*.test.ts', '**/*.test.tsx'],
+    plugins: {
+      'jest': jestPlugin,
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-non-null-assertion': 'warn',
+      'react-native/no-inline-styles': 'off',
+      'jest/no-disabled-tests': 'warn',
+      'jest/no-focused-tests': 'warn',
+      'jest/no-identical-title': 'warn',
+      'jest/valid-expect': 'warn',
+    },
+  },
+
+  // ── Scripts and JS config files (relaxed rules) ───────────────────────
+  {
+    files: ['scripts/**/*.js'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      'no-console': 'off',
+    },
+  },
+
+  // ── Prettier (must be last – disables conflicting formatting rules) ───
+  prettierConfig,
+];

--- a/dev-standards/react-native/pre-commit.rn
+++ b/dev-standards/react-native/pre-commit.rn
@@ -15,9 +15,10 @@ fi
 echo "🔍 Running React Native pre-commit checks..."
 
 # 2. console.log / console.debug verbieten (außer in scripts/)
-if git diff --cached --name-only --diff-filter=ACM \
-    | grep -E '\.(ts|tsx|js|jsx)$' | grep -v '^scripts/' \
-    | xargs grep -nE 'console\.(log|debug)' 2>/dev/null; then
+# git grep --cached durchsucht den Index direkt → robust bei Spaces/Sonderzeichen,
+# kein leeres-xargs-Problem. Exit 0 = Treffer → blocken.
+if git grep --cached -nE 'console\.(log|debug)' -- \
+     '*.ts' '*.tsx' '*.js' '*.jsx' ':!scripts/**'; then
   echo "❌ ERROR: console.log/debug in staged files (außer scripts/)."
   exit 1
 fi

--- a/dev-standards/react-native/pre-commit.rn
+++ b/dev-standards/react-native/pre-commit.rn
@@ -1,0 +1,40 @@
+#!/usr/bin/env sh
+# ─────────────────────────────────────────────────────────────────────────
+# Pre-Commit Hook – React Native / Expo (Issue #7)
+# Reihenfolge: Basis-Security → RN-spezifische Checks → lint-staged
+# Installation: nach .husky/pre-commit kopieren (sh-kompatibel halten).
+# ─────────────────────────────────────────────────────────────────────────
+
+HOOK_DIR=$(dirname "$0")
+
+# 1. Basis-Security-Checks (Fingerprints, Tokens, sensible Dateien)
+if [ -f "$HOOK_DIR/pre-commit.base" ]; then
+  . "$HOOK_DIR/pre-commit.base" || exit 1
+fi
+
+echo "🔍 Running React Native pre-commit checks..."
+
+# 2. console.log / console.debug verbieten (außer in scripts/)
+if git diff --cached --name-only --diff-filter=ACM \
+    | grep -E '\.(ts|tsx|js|jsx)$' | grep -v '^scripts/' \
+    | xargs grep -nE 'console\.(log|debug)' 2>/dev/null; then
+  echo "❌ ERROR: console.log/debug in staged files (außer scripts/)."
+  exit 1
+fi
+
+# 3. Versionskonsistenz package.json ↔ app.json
+if git diff --cached --name-only | grep -Eq '(package\.json|app\.json)'; then
+  PKG=$(node -p "require('./package.json').version" 2>/dev/null)
+  APP=$(node -p "require('./app.json').expo.version" 2>/dev/null)
+  if [ -n "$PKG" ] && [ -n "$APP" ] && [ "$PKG" != "$APP" ]; then
+    echo "❌ ERROR: Version mismatch package.json ($PKG) ↔ app.json ($APP)."
+    exit 1
+  fi
+fi
+
+# 4. lint-staged (Flat Config + Stash-Bugfix aus Issue #289)
+if [ -f node_modules/.bin/lint-staged ]; then
+  npx lint-staged --stash false --no-warn-ignored || exit 1
+fi
+
+echo "✅ React Native pre-commit checks passed."

--- a/dev-standards/react-native/tsconfig.base.json
+++ b/dev-standards/react-native/tsconfig.base.json
@@ -1,0 +1,7 @@
+{
+  "//": "Kanonische tsconfig-Basis – React Native / Expo (Issue #7). Projekte extenden diese und setzen include/exclude lokal.",
+  "extends": "expo/tsconfig.base",
+  "compilerOptions": {
+    "strict": true
+  }
+}

--- a/dev-standards/web/eslint.config.base.mjs
+++ b/dev-standards/web/eslint.config.base.mjs
@@ -1,0 +1,198 @@
+// ─────────────────────────────────────────────────────────────────────────
+// Kanonische ESLint FlatConfig (ESLint 9) – Web (React / PWA / TS)
+// Source of Truth für Issue #7. Abgeleitet aus der React-Native-Basis,
+// ohne react-native-Plugin/Globals. Source of Truth für Web-Projekte.
+// Konsumierende Projekte binden sie per Spread in ihre lokale eslint.config.mjs ein.
+// Erfordert Dev-Deps: @typescript-eslint/parser, @typescript-eslint/eslint-plugin,
+//   eslint-plugin-react, eslint-plugin-react-hooks, eslint-plugin-eslint-comments,
+//   eslint-plugin-jest, eslint-config-prettier, @eslint/compat, globals
+// ─────────────────────────────────────────────────────────────────────────
+import typescriptParser from '@typescript-eslint/parser';
+import typescriptPlugin from '@typescript-eslint/eslint-plugin';
+import reactPlugin from 'eslint-plugin-react';
+import reactHooksPlugin from 'eslint-plugin-react-hooks';
+import eslintCommentsPlugin from 'eslint-plugin-eslint-comments';
+import jestPlugin from 'eslint-plugin-jest';
+import prettierConfig from 'eslint-config-prettier';
+import { fixupPluginRules } from '@eslint/compat';
+import globals from 'globals';
+
+export default [
+  // ── Global ignores ────────────────────────────────────────────────────
+  {
+    ignores: [
+      'dist/**',
+      'build/**',
+      'node_modules/**',
+      'coverage/**',
+      '.next/**',
+      '*.config.js',
+      '*.config.mjs',
+      'jest.config.js',
+      'jest.setup.js',
+      '__mocks__/**',
+    ],
+  },
+
+  // ── Base config for TypeScript files ──────────────────────────────────
+  {
+    files: ['**/*.ts', '**/*.tsx'],
+    languageOptions: {
+      parser: typescriptParser,
+      parserOptions: {
+        sourceType: 'module',
+        ecmaFeatures: { jsx: true },
+      },
+      globals: {
+        ...globals.browser,
+        ...globals.es2021,
+      },
+    },
+    plugins: {
+      '@typescript-eslint': typescriptPlugin,
+      'react': reactPlugin,
+      'react-hooks': reactHooksPlugin,
+      'eslint-comments': fixupPluginRules(eslintCommentsPlugin),
+    },
+    settings: {
+      react: { version: 'detect' },
+    },
+    rules: {
+      // ── General ─────────────────────────────────────────────────────
+      'no-cond-assign': 'warn',
+      'no-const-assign': 'error',
+      'no-control-regex': 'warn',
+      'no-debugger': 'warn',
+      'no-dupe-class-members': 'error',
+      'no-dupe-keys': 'error',
+      'no-ex-assign': 'warn',
+      'no-extra-boolean-cast': 'warn',
+      'no-func-assign': 'warn',
+      'no-invalid-regexp': 'warn',
+      'no-obj-calls': 'warn',
+      'no-regex-spaces': 'warn',
+      'no-sparse-arrays': 'warn',
+      'no-unreachable': 'error',
+      'use-isnan': 'warn',
+      'valid-typeof': 'warn',
+
+      // ── Best Practices ──────────────────────────────────────────────
+      'dot-notation': 'warn',
+      'eqeqeq': ['error', 'always'],
+      'no-alert': 'warn',
+      'no-caller': 'warn',
+      'no-eval': 'error',
+      'no-extend-native': 'warn',
+      'no-extra-bind': 'warn',
+      'no-fallthrough': 'warn',
+      'no-implied-eval': 'warn',
+      'no-labels': 'warn',
+      'no-iterator': 'warn',
+      'no-lone-blocks': 'warn',
+      'no-new': 'warn',
+      'no-new-func': 'error',
+      'no-new-wrappers': 'warn',
+      'no-octal': 'warn',
+      'no-octal-escape': 'warn',
+      'no-proto': 'warn',
+      'no-return-assign': 'warn',
+      'no-script-url': 'warn',
+      'no-self-compare': 'warn',
+      'no-sequences': 'warn',
+      'no-useless-escape': 'warn',
+      'no-void': 'warn',
+      'radix': 'warn',
+      'yoda': 'warn',
+
+      // ── Variables ───────────────────────────────────────────────────
+      'no-delete-var': 'warn',
+      'no-global-assign': 'error',
+      'no-label-var': 'warn',
+      'no-shadow': 'off', // Handled by @typescript-eslint/no-shadow
+      'no-shadow-restricted-names': 'warn',
+      'no-undef': 'off', // Handled by TypeScript
+      'no-undef-init': 'warn',
+      'no-unused-vars': 'off', // Handled by @typescript-eslint/no-unused-vars
+
+      // ── Style ───────────────────────────────────────────────────────
+      'consistent-this': 'warn',
+      'no-array-constructor': 'warn',
+      'no-empty-character-class': 'warn',
+      'no-new-object': 'warn',
+      'no-bitwise': 'warn',
+      'no-var': 'error',
+      'prefer-const': 'error',
+      'no-console': ['warn', { allow: ['warn', 'error'] }],
+
+      // ── TypeScript ──────────────────────────────────────────────────
+      '@typescript-eslint/no-shadow': 'warn',
+      '@typescript-eslint/no-unused-vars': ['error', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        destructuredArrayIgnorePattern: '^_',
+        caughtErrors: 'none',
+      }],
+      '@typescript-eslint/no-explicit-any': 'error',
+      '@typescript-eslint/consistent-type-imports': ['error', {
+        prefer: 'type-imports',
+        fixStyle: 'separate-type-imports',
+      }],
+      '@typescript-eslint/no-non-null-assertion': 'error',
+
+      // ── React ───────────────────────────────────────────────────────
+      'react/display-name': 'off',
+      'react/jsx-no-comment-textnodes': 'error',
+      'react/jsx-no-duplicate-props': 'error',
+      'react/jsx-no-undef': 'error',
+      'react/jsx-uses-react': 'warn',
+      'react/jsx-uses-vars': 'warn',
+      'react/no-string-refs': 'error',
+      'react/no-unstable-nested-components': 'warn',
+      'react/react-in-jsx-scope': 'off',
+      'react/self-closing-comp': 'warn',
+
+      // ── React Hooks ─────────────────────────────────────────────────
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'error',
+
+      // ── ESLint Comments ─────────────────────────────────────────────
+      'eslint-comments/no-aggregating-enable': 'warn',
+      'eslint-comments/no-unlimited-disable': 'warn',
+      'eslint-comments/no-unused-disable': 'warn',
+      'eslint-comments/no-unused-enable': 'warn',
+    },
+  },
+
+  // ── Test files (relaxed rules) ────────────────────────────────────────
+  {
+    files: ['**/__tests__/**', '**/*.test.ts', '**/*.test.tsx'],
+    plugins: {
+      'jest': jestPlugin,
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-non-null-assertion': 'warn',
+      'jest/no-disabled-tests': 'warn',
+      'jest/no-focused-tests': 'warn',
+      'jest/no-identical-title': 'warn',
+      'jest/valid-expect': 'warn',
+    },
+  },
+
+  // ── Scripts and JS config files (relaxed rules) ───────────────────────
+  {
+    files: ['scripts/**/*.js'],
+    languageOptions: {
+      globals: {
+        ...globals.node,
+      },
+    },
+    rules: {
+      '@typescript-eslint/no-explicit-any': 'off',
+      'no-console': 'off',
+    },
+  },
+
+  // ── Prettier (must be last – disables conflicting formatting rules) ───
+  prettierConfig,
+];

--- a/dev-standards/web/pre-commit.web
+++ b/dev-standards/web/pre-commit.web
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+# ─────────────────────────────────────────────────────────────────────────
+# Pre-Commit Hook – Web (React / PWA / TS) (Issue #7)
+# Reihenfolge: Basis-Security → Web-spezifische Checks → lint-staged
+# Installation: nach .husky/pre-commit kopieren (sh-kompatibel halten).
+# ─────────────────────────────────────────────────────────────────────────
+
+HOOK_DIR=$(dirname "$0")
+
+# 1. Basis-Security-Checks (Fingerprints, Tokens, sensible Dateien)
+if [ -f "$HOOK_DIR/pre-commit.base" ]; then
+  . "$HOOK_DIR/pre-commit.base" || exit 1
+fi
+
+echo "🔍 Running Web pre-commit checks..."
+
+# 2. console.log / console.debug verbieten (außer in scripts/)
+if git diff --cached --name-only --diff-filter=ACM \
+    | grep -E '\.(ts|tsx|js|jsx)$' | grep -v '^scripts/' \
+    | xargs grep -nE 'console\.(log|debug)' 2>/dev/null; then
+  echo "❌ ERROR: console.log/debug in staged files (außer scripts/)."
+  exit 1
+fi
+
+# 3. lint-staged (Flat Config + Stash-Bugfix aus Issue #289)
+if [ -f node_modules/.bin/lint-staged ]; then
+  npx lint-staged --stash false --no-warn-ignored || exit 1
+fi
+
+echo "✅ Web pre-commit checks passed."

--- a/dev-standards/web/pre-commit.web
+++ b/dev-standards/web/pre-commit.web
@@ -15,9 +15,10 @@ fi
 echo "🔍 Running Web pre-commit checks..."
 
 # 2. console.log / console.debug verbieten (außer in scripts/)
-if git diff --cached --name-only --diff-filter=ACM \
-    | grep -E '\.(ts|tsx|js|jsx)$' | grep -v '^scripts/' \
-    | xargs grep -nE 'console\.(log|debug)' 2>/dev/null; then
+# git grep --cached durchsucht den Index direkt → robust bei Spaces/Sonderzeichen,
+# kein leeres-xargs-Problem. Exit 0 = Treffer → blocken.
+if git grep --cached -nE 'console\.(log|debug)' -- \
+     '*.ts' '*.tsx' '*.js' '*.jsx' ':!scripts/**'; then
   echo "❌ ERROR: console.log/debug in staged files (außer scripts/)."
   exit 1
 fi

--- a/dev-standards/web/tsconfig.base.json
+++ b/dev-standards/web/tsconfig.base.json
@@ -1,0 +1,18 @@
+{
+  "//": "Kanonische tsconfig-Basis – Web (React / PWA / TS) (Issue #7). Projekte extenden diese und setzen include/exclude lokal.",
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["ES2021", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "allowJs": false
+  }
+}

--- a/github-ruleset-protect-main-base.json
+++ b/github-ruleset-protect-main-base.json
@@ -1,0 +1,32 @@
+{
+  "name": "protect-main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/scripts/apply-rulesets.sh
+++ b/scripts/apply-rulesets.sh
@@ -51,6 +51,7 @@ if [ "${#REPOS[@]}" -eq 0 ]; then
 fi
 
 command -v gh >/dev/null 2>&1 || { echo "❌ gh CLI nicht installiert"; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "❌ jq nicht installiert (brew install jq)"; exit 1; }
 gh auth status >/dev/null 2>&1 || { echo "❌ gh nicht authentifiziert (gh auth login)"; exit 1; }
 [ -f "$RULESET_FILE" ] || { echo "❌ Ruleset-Datei fehlt: $RULESET_FILE"; exit 1; }
 

--- a/scripts/apply-rulesets.sh
+++ b/scripts/apply-rulesets.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+# ─────────────────────────────────────────────────────────────────────────
+# apply-rulesets.sh – Branch-Protection (Repository Ruleset) auf Repos anwenden.
+#
+# Basis-Regel (github-ruleset-protect-main-base.json), Open-Source mit
+# Vandalismusschutz (Issue #7, Maintainer-Entscheidung):
+#   • PR erforderlich (kein Direct-Push auf main)
+#   • non_fast_forward + deletion → kein Force-Push, kein Löschen von main
+#   • required_approving_review_count: 0 → Solo-Maintainer kann selbst mergen
+#   • Admin-Bypass (RepositoryRole 5) für Notfälle
+#
+# Sicherheit (Issue #7):
+#   • --dry-run zeigt nur, was passieren würde
+#   • Vor jedem Apply wird das bestehende Ruleset gleichen Namens als Backup
+#     nach ./ruleset-backups/<repo>-<id>-<ts>.json gesichert
+#   • Existiert bereits ein "protect-main"-Ruleset → PUT (Update) statt POST
+#
+# Usage:
+#   ./apply-rulesets.sh [--dry-run] [repo1 repo2 ...]   # default: alle bekannten
+# ─────────────────────────────────────────────────────────────────────────
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+OWNER="S540d"
+RULESET_FILE="$ROOT_DIR/github-ruleset-protect-main-base.json"
+RULESET_NAME="protect-main"
+BACKUP_DIR="$ROOT_DIR/ruleset-backups"
+
+DRY_RUN=0
+REPOS=()
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    -h|--help) grep -E '^#( |$)' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) REPOS+=("$arg") ;;
+  esac
+done
+
+if [ "${#REPOS[@]}" -eq 0 ]; then
+  REPOS=(
+    "EnergyPriceGermany"
+    "CD-to-Spotify-PWA"
+    "1x1_Trainer"
+    "DrawFromMemory"
+    "Eisenhauer"
+    "Pflanzkalender"
+    "safe_my_plants"
+  )
+fi
+
+command -v gh >/dev/null 2>&1 || { echo "❌ gh CLI nicht installiert"; exit 1; }
+gh auth status >/dev/null 2>&1 || { echo "❌ gh nicht authentifiziert (gh auth login)"; exit 1; }
+[ -f "$RULESET_FILE" ] || { echo "❌ Ruleset-Datei fehlt: $RULESET_FILE"; exit 1; }
+
+[ "$DRY_RUN" -eq 1 ] && echo "🔎 DRY-RUN: keine Änderungen werden geschrieben."
+
+for repo in "${REPOS[@]}"; do
+  echo "→ $OWNER/$repo"
+
+  # Existierendes "protect-main"-Ruleset suchen.
+  # API kann bei 404/fehlender Berechtigung ein Objekt statt Array liefern →
+  # defensiv parsen (nur Arrays durchsuchen), sonst leeres Ergebnis.
+  existing_id="$(gh api "repos/$OWNER/$repo/rulesets" 2>/dev/null \
+    | jq -r --arg n "$RULESET_NAME" \
+        'if type=="array" then (.[] | select(.name == $n) | .id) else empty end' \
+        2>/dev/null | head -n1 || true)"
+
+  if [ -n "${existing_id:-}" ] && [ "$existing_id" != "null" ]; then
+    # Backup vor Update
+    mkdir -p "$BACKUP_DIR"
+    backup="$BACKUP_DIR/${repo}-${existing_id}-$(date +%Y%m%d-%H%M%S).json"
+    if [ "$DRY_RUN" -eq 0 ]; then
+      gh api "repos/$OWNER/$repo/rulesets/$existing_id" > "$backup" 2>/dev/null \
+        && echo "  💾 Backup: $backup"
+    else
+      echo "  [dry-run] Backup würde nach $backup geschrieben"
+    fi
+
+    echo "  ↻ Update bestehendes Ruleset (id=$existing_id) via PUT"
+    if [ "$DRY_RUN" -eq 0 ]; then
+      if gh api "repos/$OWNER/$repo/rulesets/$existing_id" --method PUT --input "$RULESET_FILE" >/dev/null 2>&1; then
+        echo "  ✅ aktualisiert"
+      else
+        echo "  ⚠️  Update fehlgeschlagen (Berechtigung?)"
+      fi
+    fi
+  else
+    echo "  + Neues Ruleset via POST"
+    if [ "$DRY_RUN" -eq 0 ]; then
+      if gh api "repos/$OWNER/$repo/rulesets" --method POST --input "$RULESET_FILE" >/dev/null 2>&1; then
+        echo "  ✅ erstellt"
+      else
+        echo "  ⚠️  Erstellung fehlgeschlagen (Berechtigung? bereits vorhanden?)"
+      fi
+    fi
+  fi
+done
+
+echo "✅ Ruleset-Rollout abgeschlossen."

--- a/scripts/sync-standards.sh
+++ b/scripts/sync-standards.sh
@@ -48,14 +48,16 @@ POLICY_FILE="$ROOT_DIR/dev-standards/base/global-policy.md"
 POLICY_BODY="$(cat "$POLICY_FILE")"
 
 run() {
+  # Führt Kommando + Argumente direkt aus (kein eval → kein Injection-/Quoting-Risiko).
   if [ "$DRY_RUN" -eq 1 ]; then
     echo "   [dry-run] $*"
   else
-    eval "$@"
+    "$@"
   fi
 }
 
 # Ersetzt den GLOBAL-POLICY-Marker-Block in einer CLAUDE.md idempotent.
+# Schreibt atomar (mktemp + mv) und ersetzt den Block AN ORT UND STELLE.
 sync_policy_block() {
   local claude_file="$1"
   local block
@@ -69,32 +71,42 @@ sync_policy_block() {
     return
   fi
 
-  if grep -Fq "$MARKER_START" "$claude_file"; then
-    echo "   ↻ Aktualisiere bestehenden GLOBAL-POLICY-Block (Rest unberührt)"
-    if [ "$DRY_RUN" -eq 0 ]; then
-      local tmp
-      tmp="$(mktemp)"
-      # Alles ohne den alten Block + ohne nachlaufende Leerzeilen (kein Aufstauen
-      # von Leerzeilen über mehrere Läufe), dann genau eine Leerzeile + Block.
-      awk -v s="$MARKER_START" -v e="$MARKER_END" '
-        $0 ~ s {skip=1; next}
-        $0 ~ e {skip=0; next}
-        skip==1 {next}
-        # Leerzeilen puffern und erst vor echtem Inhalt ausgeben → trimmt das Ende
-        /^[[:space:]]*$/ {blank++; next}
-        { while (blank-- > 0) print ""; blank=0; print }
-      ' "$claude_file" > "$tmp"
-      {
-        cat "$tmp"
-        printf '\n%s\n' "$block"
-      } > "$claude_file"
-      rm -f "$tmp"
-    fi
+  local has_start=0 has_end=0
+  grep -Fq "$MARKER_START" "$claude_file" && has_start=1
+  grep -Fq "$MARKER_END"   "$claude_file" && has_end=1
+
+  # Beschädigt: nur START ohne END → NICHT bis EOF löschen (würde lokale Inhalte
+  # fressen). Sicher überspringen und melden, statt Datenverlust zu riskieren.
+  if [ "$has_start" -eq 1 ] && [ "$has_end" -eq 0 ]; then
+    echo "   ⚠️  START-Marker ohne END in $claude_file – manuell reparieren. Übersprungen (kein Datenverlust)."
+    return
+  fi
+
+  if [ "$has_start" -eq 1 ] && [ "$has_end" -eq 1 ]; then
+    echo "   ↻ Ersetze GLOBAL-POLICY-Block an Ort und Stelle (Rest unberührt)"
+    [ "$DRY_RUN" -eq 0 ] || return
+    local tmp blockfile
+    tmp="$(mktemp "${claude_file}.XXXXXX")"
+    # Mehrzeiligen Block über eine Datei einspeisen – awk -v verträgt keine
+    # Newlines (BSD awk bricht mit "newline in string" ab). Ersetzung an Ort
+    # und Stelle: an Startposition Block-Datei ausgeben, alten Block bis END verwerfen.
+    blockfile="$(mktemp)"
+    printf '%s\n' "$block" > "$blockfile"
+    awk -v s="$MARKER_START" -v e="$MARKER_END" -v bf="$blockfile" '
+      $0 ~ s { while ((getline line < bf) > 0) print line; close(bf); skip=1; next }
+      $0 ~ e { skip=0; next }
+      skip!=1 { print }
+    ' "$claude_file" > "$tmp" && mv "$tmp" "$claude_file" || { rm -f "$tmp" "$blockfile"; return 1; }
+    rm -f "$blockfile"
   else
     echo "   + Hänge GLOBAL-POLICY-Block einmalig an (CLAUDE.md sonst unberührt)"
-    if [ "$DRY_RUN" -eq 0 ]; then
-      printf '\n\n%s\n' "$block" >> "$claude_file"
-    fi
+    [ "$DRY_RUN" -eq 0 ] || return
+    local tmp
+    tmp="$(mktemp "${claude_file}.XXXXXX")"
+    {
+      cat "$claude_file"
+      printf '\n%s\n' "$block"
+    } > "$tmp" && mv "$tmp" "$claude_file" || { rm -f "$tmp"; return 1; }
   fi
 }
 
@@ -111,16 +123,17 @@ copy_to_project() {
   # 1. Claude Commands – überschreiben ist gewollt (Issue #7)
   # (Verzeichnis kommt mit PR B; glob-sicher, falls leer/abwesend.)
   if compgen -G "$ROOT_DIR/claude-commands/*.md" > /dev/null; then
-    run "mkdir -p '$project_dir/.claude/commands'"
-    run "cp '$ROOT_DIR'/claude-commands/*.md '$project_dir/.claude/commands/'"
+    run mkdir -p "$project_dir/.claude/commands"
+    # Glob wird hier (nicht in run) expandiert → cp erhält echte Dateiargumente.
+    run cp "$ROOT_DIR"/claude-commands/*.md "$project_dir/.claude/commands/"
     echo "   ✓ Claude Commands synchronisiert"
   else
     echo "   • Keine claude-commands/*.md vorhanden – übersprungen"
   fi
 
   # 2. Basis-Konfig – Prettier + EditorConfig
-  run "cp '$ROOT_DIR/dev-standards/base/.prettierrc.json' '$project_dir/.prettierrc.json'"
-  run "cp '$ROOT_DIR/dev-standards/base/.editorconfig' '$project_dir/.editorconfig'"
+  run cp "$ROOT_DIR/dev-standards/base/.prettierrc.json" "$project_dir/.prettierrc.json"
+  run cp "$ROOT_DIR/dev-standards/base/.editorconfig" "$project_dir/.editorconfig"
   echo "   ✓ .prettierrc.json + .editorconfig synchronisiert"
 
   # 3. GLOBAL POLICY – idempotenter Marker-Block, CLAUDE.md bleibt sonst unberührt

--- a/scripts/sync-standards.sh
+++ b/scripts/sync-standards.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# ─────────────────────────────────────────────────────────────────────────
+# sync-standards.sh – Verteilt Standards aus project-templates in Projekte.
+#
+# Synchronisiert:
+#   • Claude Commands  → .claude/commands/   (überschreibt – gewollt, Issue #7)
+#   • .prettierrc.json + .editorconfig → Projekt-Root (Basis)
+#   • GLOBAL POLICY    → CLAUDE.md   (idempotenter Marker-Block, NIE Überschreiben)
+#
+# CLAUDE.md-Schutz (Issue #7, Entscheidung Maintainer):
+#   Lokale CLAUDE.md darf NICHT überschrieben werden. Nur der Bereich zwischen
+#   <!-- GLOBAL POLICY:START --> und <!-- GLOBAL POLICY:END --> wird ersetzt.
+#   Existiert kein Marker, wird der Block EINMALIG ans Ende angehängt.
+#   Mehrfaches Ausführen ist idempotent (keine Duplikate, Updates greifen).
+#
+# Usage:
+#   ./sync-standards.sh [--dry-run] /abs/path/projectA [/abs/path/projectB ...]
+# ─────────────────────────────────────────────────────────────────────────
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+
+DRY_RUN=0
+PROJECTS=()
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    -h|--help)
+      grep -E '^#( |$)' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *) PROJECTS+=("$arg") ;;
+  esac
+done
+
+if [ "${#PROJECTS[@]}" -eq 0 ]; then
+  echo "Usage: $0 [--dry-run] /abs/path/project [/abs/path/project2 ...]"
+  exit 1
+fi
+
+MARKER_START="<!-- GLOBAL POLICY:START -->"
+MARKER_END="<!-- GLOBAL POLICY:END -->"
+
+# Policy-Text liegt als eigene Datei vor (Single Source of Truth).
+POLICY_FILE="$ROOT_DIR/dev-standards/base/global-policy.md"
+[ -f "$POLICY_FILE" ] || { echo "❌ Policy-Datei fehlt: $POLICY_FILE"; exit 1; }
+POLICY_BODY="$(cat "$POLICY_FILE")"
+
+run() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    echo "   [dry-run] $*"
+  else
+    eval "$@"
+  fi
+}
+
+# Ersetzt den GLOBAL-POLICY-Marker-Block in einer CLAUDE.md idempotent.
+sync_policy_block() {
+  local claude_file="$1"
+  local block
+  block="${MARKER_START}"$'\n'"${POLICY_BODY}"$'\n'"${MARKER_END}"
+
+  if [ ! -f "$claude_file" ]; then
+    echo "   ⚠️  Keine CLAUDE.md – lege Minimal-Datei mit Policy-Block an: $claude_file"
+    if [ "$DRY_RUN" -eq 0 ]; then
+      printf '%s\n' "$block" > "$claude_file"
+    fi
+    return
+  fi
+
+  if grep -Fq "$MARKER_START" "$claude_file"; then
+    echo "   ↻ Aktualisiere bestehenden GLOBAL-POLICY-Block (Rest unberührt)"
+    if [ "$DRY_RUN" -eq 0 ]; then
+      local tmp
+      tmp="$(mktemp)"
+      # Alles ohne den alten Block + ohne nachlaufende Leerzeilen (kein Aufstauen
+      # von Leerzeilen über mehrere Läufe), dann genau eine Leerzeile + Block.
+      awk -v s="$MARKER_START" -v e="$MARKER_END" '
+        $0 ~ s {skip=1; next}
+        $0 ~ e {skip=0; next}
+        skip==1 {next}
+        # Leerzeilen puffern und erst vor echtem Inhalt ausgeben → trimmt das Ende
+        /^[[:space:]]*$/ {blank++; next}
+        { while (blank-- > 0) print ""; blank=0; print }
+      ' "$claude_file" > "$tmp"
+      {
+        cat "$tmp"
+        printf '\n%s\n' "$block"
+      } > "$claude_file"
+      rm -f "$tmp"
+    fi
+  else
+    echo "   + Hänge GLOBAL-POLICY-Block einmalig an (CLAUDE.md sonst unberührt)"
+    if [ "$DRY_RUN" -eq 0 ]; then
+      printf '\n\n%s\n' "$block" >> "$claude_file"
+    fi
+  fi
+}
+
+copy_to_project() {
+  local project_dir="$1"
+
+  if [ ! -d "$project_dir" ]; then
+    echo "⚠️  Überspringe (kein Verzeichnis): $project_dir"
+    return
+  fi
+
+  echo "→ Sync: $project_dir"
+
+  # 1. Claude Commands – überschreiben ist gewollt (Issue #7)
+  # (Verzeichnis kommt mit PR B; glob-sicher, falls leer/abwesend.)
+  if compgen -G "$ROOT_DIR/claude-commands/*.md" > /dev/null; then
+    run "mkdir -p '$project_dir/.claude/commands'"
+    run "cp '$ROOT_DIR'/claude-commands/*.md '$project_dir/.claude/commands/'"
+    echo "   ✓ Claude Commands synchronisiert"
+  else
+    echo "   • Keine claude-commands/*.md vorhanden – übersprungen"
+  fi
+
+  # 2. Basis-Konfig – Prettier + EditorConfig
+  run "cp '$ROOT_DIR/dev-standards/base/.prettierrc.json' '$project_dir/.prettierrc.json'"
+  run "cp '$ROOT_DIR/dev-standards/base/.editorconfig' '$project_dir/.editorconfig'"
+  echo "   ✓ .prettierrc.json + .editorconfig synchronisiert"
+
+  # 3. GLOBAL POLICY – idempotenter Marker-Block, CLAUDE.md bleibt sonst unberührt
+  sync_policy_block "$project_dir/CLAUDE.md"
+}
+
+for project in "${PROJECTS[@]}"; do
+  copy_to_project "$project"
+done
+
+cat <<'NOTE'
+
+✅ Sync abgeschlossen.
+
+⚠️  Prettier-Baseline (Issue #7, Punkt 5):
+   Der erste Prettier-Lauf erzeugt große Reformat-Diffs. Pro Projekt EINMALIG
+   isoliert committen, NICHT mit Feature-Arbeit mischen:
+
+     npx prettier --write .
+     git add -A && git commit -m "style: prettier baseline (project-templates)"
+     git rev-parse HEAD >> .git-blame-ignore-revs
+     git add .git-blame-ignore-revs && git commit -m "chore: ignore prettier baseline in git blame"
+     git config blame.ignoreRevsFile .git-blame-ignore-revs
+NOTE

--- a/ux-vorgaben.md
+++ b/ux-vorgaben.md
@@ -3,7 +3,7 @@
 
 Allgemeine UX/UI Standards für konsistente, benutzerfreundliche Interfaces über alle Projekte hinweg.
 
-> **Zuletzt aktualisiert:** 2026-01-07
+> **Zuletzt aktualisiert:** 2026-03-14
 > **Hinweis:** Technische Implementierungsdetails (Android Edge-to-Edge, OTA Updates, App Links, etc.) finden sich in [technische_vorgaben.md](technische_vorgaben.md)
 > **Konsolidierung:** Diese Datei integriert nun auch Inhalte aus design-system.md und DESIGN_GUIDELINES.md für eine einheitliche UX-Dokumentation
 
@@ -600,9 +600,10 @@ Support-Links im Settings-Menü sind Standard-Praxis und gelten NICHT als "In-Ap
 ## Interaktion & Feedback
 
 ### Loading States
-- **Spinner:** Rotierendes Icon oder Skeleton-Screen
+- **Skeleton-Screen:** Bevorzugt statt Spinner (siehe "Skeleton Loading" oben)
+- **Spinner:** Nur als Fallback wenn Skeleton nicht sinnvoll
 - **Duration:** Max. 3 Sekunden ohne Feedback (dann Nachrichten zeigen)
-- **Text:** "Loading...", "Saving...", etc.
+- **Text:** "Loading...", "Saving...", etc. (für Screen Reader via `accessibilityRole="alert"`)
 - **Disable:** Buttons/Inputs während Loading disablen
 
 ### Success/Error Messages
@@ -611,11 +612,94 @@ Support-Links im Settings-Menü sind Standard-Praxis und gelten NICHT als "In-Ap
 - **Position:** Oben rechts (Desktop), Oben Mitte (Mobile)
 - **Icon:** Visual Indicator (✓, ✕, ⚠, ℹ)
 
-### Animations
+### Animations & Micro-Interactions ⭐
+
+> **Referenz-Implementierung:** EnergyPriceGermany v1.5.0 (PR #244)
+> **Bibliothek:** `react-native-reanimated` 3.17+ (empfohlen für alle Expo-Apps)
+
+#### Animation-Grundsätze
 - **Duration:** 200-300ms für Hover/Focus, 300-500ms für Page Transitions
 - **Easing:** `ease-out` für Erscheinen, `ease-in` für Verschwinden
 - **Reduzieren:** `prefers-reduced-motion: reduce` respektieren
 - **Keine flashing:** Nichts sollte schneller als 3x pro Sekunde blinken
+
+#### Micro-Animation Katalog (PFLICHT für alle Expo-Apps)
+
+**Card Mount Animation:**
+```tsx
+// Fade-in + translateY bei Mount
+const opacity = useSharedValue(0);
+const translateY = useSharedValue(8);
+useEffect(() => {
+  opacity.value = withTiming(1, { duration: 350 });
+  translateY.value = withTiming(0, { duration: 350 });
+}, []);
+```
+
+**Button Press Spring:**
+```tsx
+// Scale-Spring auf Press
+const scale = useSharedValue(1);
+const onPressIn = () => { scale.value = withSpring(0.95); };
+const onPressOut = () => { scale.value = withSpring(1); };
+```
+
+**Tooltip Appear:**
+```tsx
+// Scale + Fade bei Erscheinen
+const opacity = useSharedValue(0);
+const scale = useSharedValue(0.9);
+useEffect(() => {
+  opacity.value = withTiming(1, { duration: 150 });
+  scale.value = withTiming(1, { duration: 150 });
+}, []);
+```
+
+**Settings Menu Slide:**
+```tsx
+// Slide-up/down via isMounted-Pattern
+// Mount: height 0 → auto, opacity 0 → 1
+// Unmount: reverse
+```
+
+**Theme Toggle Pill:**
+```tsx
+// Animierter Pill-Schieberegler
+// Positionen via onLayout gemessen
+// Wechsel via withSpring (Pill gleitet unter aktiven Button)
+```
+
+#### Setup für Reanimated in Expo
+1. `npx expo install react-native-reanimated`
+2. `babel.config.js`: Plugin ergänzen (NACH `babel-preset-expo`):
+   ```js
+   plugins: ['react-native-reanimated/plugin']
+   ```
+3. `global.d.ts` anlegen für TS-Typen
+4. **WICHTIG:** Keine manuellen Babel-Presets (`@babel/preset-env` etc.) - sonst Hermes-Build-Fehler!
+
+### Skeleton Loading (PFLICHT für alle Expo-Apps) ⭐
+
+> Ersetzt ActivityIndicator durch visuell ansprechendere Shimmer-Animationen.
+
+#### Shimmer-Skeleton mit LinearGradient
+```tsx
+// SkeletonLoader.tsx - Shimmer via expo-linear-gradient
+// Horizontaler Gradient wandert via useSharedValue+withRepeat über den Container
+// Dark-Mode-aware Farben
+import { LinearGradient } from 'expo-linear-gradient';
+import Animated, { useSharedValue, withRepeat, withTiming } from 'react-native-reanimated';
+```
+
+#### Einsatzgebiete
+- **App-Start:** Skeleton statt Spinner während Daten laden
+- **Charts:** Chart-förmige Skeleton-Platzhalter
+- **Listen:** Zeilen-förmige Skeleton-Platzhalter
+- **Cards:** Card-förmige Skeleton mit korrekten Dimensionen
+
+#### Abhängigkeiten
+- `expo-linear-gradient` (für Shimmer-Effekt)
+- `react-native-reanimated` (für Animation)
 
 ### Hover & Focus States
 - **Hover:** Farb-Change, Schatten, oder Scale (max 1.05)
@@ -1250,6 +1334,43 @@ const shareApp = async () => {
 - **compileSdk/targetSdk:** 36+
 - **themes.xml:** Transparente System Bars
 - Separate Dark Mode Themes
+
+### Android Rendering Gotchas (ältere Geräte)
+
+#### Problem 1: Weißer Kasten bei `elevation` + transparentem Background
+
+Android zeichnet `elevation` (Schatten) auf einem opaken Layer. Ein View mit `backgroundColor: 'transparent'` und `elevation > 0` erzeugt automatisch einen weißen rechteckigen Hintergrund — unabhängig von der gesetzten `backgroundColor`.
+
+```typescript
+// ❌ Erzeugt weißen Kasten auf älterem Android
+{ backgroundColor: 'transparent', elevation: 1 }
+
+// ✅ Kein weißer Kasten
+{ backgroundColor: 'transparent', elevation: 0 }
+```
+
+**Faustregel:** `elevation` nur verwenden, wenn der View einen sichtbaren, opaken Background hat. `shadowColor`/`shadowOffset`/`shadowOpacity` sind iOS-only und verursachen das Problem nicht.
+
+#### Problem 2: Unsichtbarer Text durch `fontWeight: '600'`
+
+Ältere Android-Geräte unterstützen nur zwei Gewichtsstufen: `'normal'` (400) und `'bold'` (700). Numerische Zwischenwerte wie `'600'`, `'500'` oder `'300'` werden nicht interpoliert — der Text wird unsichtbar dünn oder gar nicht gerendert.
+
+```typescript
+// ❌ Kann auf älterem Android unsichtbar werden
+{ fontWeight: '600' }
+{ fontWeight: '500' }
+
+// ✅ Universell unterstützt
+{ fontWeight: 'bold' }    // = '700'
+{ fontWeight: 'normal' }  // = '400'
+```
+
+**Faustregel:** Nur `'normal'`, `'bold'`, `'400'` oder `'700'` verwenden, es sei denn eine Custom Font mit explizitem Gewicht ist geladen.
+
+#### Checkliste
+- [ ] Kein `elevation > 0` in Kombination mit `transparent` Background
+- [ ] Kein `fontWeight` mit Werten außer `'normal'`/`'bold'`/`'400'`/`'700'`
+- [ ] Besonders in wiederverwendbaren Komponenten (Buttons, Chips, Badges) prüfen
 
 ### Web (React Native Web / Standard Web)
 


### PR DESCRIPTION
Setzt **Issue #7 Teil 1** um – orientiert an den RFC-Ideen + den Maintainer-Entscheidungen aus den Issue-Kommentaren. Bewusst **unabhängig von Copilot-PR #8** neu gebaut.

Closes Teil 1 von #7 (Teil 2 folgt: restliche Reusable Workflows + Commands).

## Was ist drin

### `dev-standards/` – kanonische Source of Truth
- `base/`: `.prettierrc.json` (akzeptierte Werte), `.editorconfig`, `pre-commit.base` (Security-Checks: Signing-Fingerprints + Tokens + sensible Dateien, aus #276), `global-policy.md`
- `react-native/`: **echte erprobte ESLint FlatConfig** aus EnergyPriceGermany (kein leerer Platzhalter), `tsconfig.base.json`, `pre-commit.rn`
- `web/`: ESLint FlatConfig (ohne RN-Plugin), `tsconfig.base.json`, `pre-commit.web`

### `scripts/sync-standards.sh`
- Verteilt Commands + Prettier/EditorConfig in Projekte
- **GLOBAL POLICY via idempotentem Marker-Block** (`<!-- GLOBAL POLICY:START/END -->`) → lokale `CLAUDE.md` bleibt unangetastet (Entscheidung zu Punkt 3)
- `--dry-run`; E2E getestet: append → update-in-place → tamper-reset, keine Leerzeilen-Akkumulation, lokaler Inhalt bleibt erhalten

### `scripts/apply-rulesets.sh` + `github-ruleset-protect-main-base.json`
- Branch-Protection für **Open-Source mit Vandalismusschutz** (Punkt 2): PR-Pflicht, kein Force-Push/Delete auf `main`, `required_approving_review_count: 0` (Solo-Merge möglich), Admin-Bypass
- `--dry-run` + Backup bestehender Rulesets + **PUT-Update** statt blindem POST

### `.github/workflows/reusable-security-scan.yml`
- Pilot-Reusable-Workflow, **fail-closed** (Scanner-Fehler UND Funde brechen ab – Punkt 1)
- Konsumenten pinnen auf `@v1`, **nie `@main`** (im Header dokumentiert)

### Aufräumen
- Legacy `automation-templates/.eslintrc.js` als **deprecated** markiert (Punkt 4) → eine Source of Truth

## Tests
- `bash -n` für alle Scripts ✅
- `jq` Validierung aller JSON ✅
- sync-standards.sh E2E gegen Wegwerf-CLAUDE.md (Idempotenz + CLAUDE.md-Schutz) ✅
- apply-rulesets.sh `--dry-run` ✅

## Offene Folge-Punkte (Teil 2 / nach Merge)
- `@v1`-Tag auf dem Repo setzen, sobald dies auf `main` ist
- Restliche Reusable Workflows (`ci-quality`, `gitignore-audit`, `dev-standards-audit`, `weekly-audit`) + `claude-commands/` (Teil-2-PR)
- `weekly-audit`: fine-grained `ORG_AUTOMATION_TOKEN` + `repository_dispatch`-Listener (Punkt 6)
- Prettier-Baseline-Commit pro Projekt beim Rollout (Punkt 5, im Sync-Output dokumentiert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)