### PR TITLE
feat(#7): Reusable Workflows + Claude Commands (Teil 2)

### DIFF
--- a/.github/workflows/reusable-ci-quality.yml
+++ b/.github/workflows/reusable-ci-quality.yml
@@ -1,0 +1,76 @@
+name: Reusable CI Quality
+
+# Konfigurierbarer Lint/Type-Check/Test-Job (Issue #7). Aufruf versioniert (@v1):
+#
+#   jobs:
+#     quality:
+#       uses: S540d/project-templates/.github/workflows/reusable-ci-quality.yml@v1
+#       with:
+#         node_version: '20'
+#         run_lint: true
+#         run_typecheck: true
+#         run_tests: true
+
+on:
+  workflow_call:
+    inputs:
+      node_version:
+        description: 'Node.js Version'
+        required: false
+        type: string
+        default: '20'
+      run_lint:
+        required: false
+        type: boolean
+        default: true
+      run_typecheck:
+        required: false
+        type: boolean
+        default: true
+      run_tests:
+        required: false
+        type: boolean
+        default: true
+      lint_command:
+        required: false
+        type: string
+        default: 'npm run lint'
+      typecheck_command:
+        required: false
+        type: string
+        default: 'npm run type-check'
+      test_command:
+        required: false
+        type: string
+        default: 'npm test'
+
+permissions:
+  contents: read
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node_version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        if: ${{ inputs.run_lint }}
+        run: ${{ inputs.lint_command }}
+
+      - name: Type-Check
+        if: ${{ inputs.run_typecheck }}
+        run: ${{ inputs.typecheck_command }}
+
+      - name: Tests
+        if: ${{ inputs.run_tests }}
+        run: ${{ inputs.test_command }}

--- a/.github/workflows/reusable-dev-standards-audit.yml
+++ b/.github/workflows/reusable-dev-standards-audit.yml
@@ -1,0 +1,55 @@
+name: Reusable Dev-Standards Audit
+
+# NON-BLOCKING Audit (Issue #7): meldet Abweichungen von den Dev-Standards,
+# bricht den Build aber NICHT ab. Aufruf versioniert (@v1):
+#
+#   jobs:
+#     standards:
+#       uses: S540d/project-templates/.github/workflows/reusable-dev-standards-audit.yml@v1
+
+on:
+  workflow_call: {}
+
+permissions:
+  contents: read
+
+jobs:
+  dev-standards-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Audit Dev-Standards (non-blocking)
+        shell: bash
+        run: |
+          # Bewusst non-blocking: nur Hinweise, kein exit 1.
+          check() {
+            if [ -e "$1" ]; then
+              echo "✅ $1 vorhanden"
+            else
+              echo "::warning title=Standard fehlt::$1 fehlt ($2)"
+            fi
+          }
+
+          echo "::group::Dev-Standards Audit"
+          check ".prettierrc.json"   "Prettier-Config (sync-standards.sh)"
+          check ".editorconfig"      "EditorConfig (sync-standards.sh)"
+          check ".husky/pre-commit"  "Husky Pre-Commit Hook"
+
+          # ESLint: FlatConfig bevorzugt, Legacy nur Hinweis
+          if [ -e "eslint.config.mjs" ] || [ -e "eslint.config.js" ]; then
+            echo "✅ ESLint FlatConfig vorhanden"
+          elif [ -e ".eslintrc.js" ] || [ -e ".eslintrc.json" ]; then
+            echo "::warning title=Legacy ESLint::.eslintrc gefunden – auf FlatConfig migrieren (Issue #7)"
+          else
+            echo "::warning title=Kein ESLint::Keine ESLint-Config gefunden"
+          fi
+
+          # GLOBAL POLICY in CLAUDE.md?
+          if [ -f "CLAUDE.md" ] && grep -Fq "GLOBAL POLICY:START" CLAUDE.md; then
+            echo "✅ GLOBAL POLICY in CLAUDE.md synchronisiert"
+          else
+            echo "::warning title=GLOBAL POLICY fehlt::sync-standards.sh ausführen"
+          fi
+          echo "::endgroup::"

--- a/.github/workflows/reusable-gitignore-audit.yml
+++ b/.github/workflows/reusable-gitignore-audit.yml
@@ -1,0 +1,73 @@
+name: Reusable Gitignore Audit
+
+# Prüft Pflicht-Ignore-Einträge + dass keine sensiblen Dateien getrackt werden (Issue #7).
+# Da alle Projekte ÖFFENTLICH sind (Punkt 7), ist der Audit standardmäßig BLOCKING.
+# Aufruf versioniert (@v1):
+#
+#   jobs:
+#     gitignore:
+#       uses: S540d/project-templates/.github/workflows/reusable-gitignore-audit.yml@v1
+
+on:
+  workflow_call:
+    inputs:
+      fail_on_missing:
+        description: 'Bei fehlenden Pflicht-Einträgen / getrackten Secrets hart fehlschlagen'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+jobs:
+  gitignore-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Audit .gitignore und getrackte Dateien
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          problems=0
+
+          if [ ! -f .gitignore ]; then
+            echo "::error title=.gitignore fehlt::Eine .gitignore ist erforderlich"
+            exit 1
+          fi
+
+          # Pflicht-Einträge (Issue #7)
+          required=(
+            ".env"
+            "credentials.json"
+            "*.jks"
+            "*.keystore"
+            "docs/private/"
+          )
+          for entry in "${required[@]}"; do
+            if ! grep -Fq "$entry" .gitignore; then
+              echo "::warning title=Fehlender .gitignore-Eintrag::'$entry' nicht in .gitignore"
+              problems=1
+            fi
+          done
+
+          # Sensible Dateien dürfen NICHT getrackt sein (öffentliches Repo!)
+          if git ls-files | grep -E '(^|/)(\.env(\..+)?$|credentials\.json$|.*\.jks$|.*\.keystore$|.*\.p12$|.*\.p8$)'; then
+            echo "::error title=Sensible Datei getrackt::credentials/keystore/env im öffentlichen Repo"
+            problems=1
+          fi
+
+          # docs/private/ darf nicht getrackt sein
+          if git ls-files | grep -E '^docs/private/'; then
+            echo "::error title=docs/private getrackt::Interne Docs dürfen nicht im Repo sein"
+            problems=1
+          fi
+
+          if [ "$problems" -ne 0 ] && [ "${{ inputs.fail_on_missing }}" = "true" ]; then
+            echo "Gitignore-Audit fehlgeschlagen."
+            exit 1
+          fi
+          echo "Gitignore-Audit abgeschlossen."

--- a/.github/workflows/weekly-audit.yml
+++ b/.github/workflows/weekly-audit.yml
@@ -1,0 +1,69 @@
+name: Weekly Cross-Project Audit
+
+# Cron montags 08:00 (Issue #7): triggert in jedem Ziel-Repo einen Self-Audit
+# via repository_dispatch (event_type: weekly-self-audit).
+#
+# ⚠️ TOKEN-SCOPE (Issue #7, Punkt 6):
+#   Der Default-GITHUB_TOKEN kann KEINE fremden Repos dispatchen. Es ist ein
+#   dediziertes Secret ORG_AUTOMATION_TOKEN erforderlich:
+#     - Fine-grained PAT, minimaler Scope: "Contents: read" + "Actions: write"
+#       NUR auf die unten gelisteten Ziel-Repos.
+#     - Als Repo-Secret in project-templates hinterlegen (Settings → Secrets).
+#   Ohne dieses Token laufen die Dispatches still ins Leere (pro Repo ::warning).
+#
+# Jedes Ziel-Repo braucht zusätzlich einen Listener:
+#     on:
+#       repository_dispatch:
+#         types: [weekly-self-audit]
+#   (wird per sync-standards ausgerollt – siehe Folge-PR / Issue #7).
+
+on:
+  schedule:
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+    inputs:
+      repos:
+        description: 'Komma-separierte Repos (leer = Default-Liste)'
+        required: false
+        type: string
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  trigger-self-scans:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.ORG_AUTOMATION_TOKEN }}
+      DEFAULT_REPOS: 'EnergyPriceGermany,CD-to-Spotify-PWA,1x1_Trainer,DrawFromMemory,Eisenhauer,Pflanzkalender,safe_my_plants'
+    steps:
+      - name: Token vorhanden?
+        shell: bash
+        run: |
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "::error title=ORG_AUTOMATION_TOKEN fehlt::Fine-grained PAT als Secret hinterlegen (Issue #7, Punkt 6)"
+            exit 1
+          fi
+
+      - name: Dispatch weekly-self-audit
+        shell: bash
+        run: |
+          set -euo pipefail
+          REPOS="${{ inputs.repos }}"
+          [ -n "$REPOS" ] || REPOS="$DEFAULT_REPOS"
+
+          IFS=',' read -r -a list <<< "$REPOS"
+          for raw in "${list[@]}"; do
+            repo="$(echo "$raw" | xargs)"
+            [ -n "$repo" ] || continue
+            echo "→ Dispatch S540d/$repo"
+            if gh api "repos/S540d/$repo/dispatches" \
+                 --method POST \
+                 --field event_type='weekly-self-audit' \
+                 --field 'client_payload[source]=project-templates/weekly-audit'; then
+              echo "  ✅ ausgelöst"
+            else
+              echo "::warning title=Dispatch fehlgeschlagen::S540d/$repo (Token-Scope? Listener?)"
+            fi
+          done

--- a/README.md
+++ b/README.md
@@ -162,9 +162,15 @@ Zentrale Vorlagen und Standards für alle Projekte. Diese Templates definieren B
      Branch-Protection (Open-Source mit Vandalismusschutz): PR-Pflicht, kein Force-Push/Delete
      auf main, `required_approving_review_count: 0` (Solo-Merge möglich), Admin-Bypass.
      **`--dry-run`** + automatisches Backup bestehender Rulesets + PUT-Update statt blindem POST.
-   - **`.github/workflows/reusable-security-scan.yml`** – Pilot-Reusable-Workflow,
-     **fail-closed** (Scanner-Fehler UND Funde brechen ab). Konsumierende Repos pinnen auf `@v1`,
-     **nie `@main`**.
+   - **Reusable Workflows** (`.github/workflows/`) – versioniert aufrufen (`@v1`, **nie `@main`**):
+     - `reusable-security-scan.yml` – **fail-closed** (Scanner-Fehler UND Funde brechen ab)
+     - `reusable-ci-quality.yml` – konfigurierbar (lint/type-check/test, Node-Version, Commands)
+     - `reusable-gitignore-audit.yml` – **blocking** (alle Repos öffentlich): Pflicht-Ignores + keine getrackten Secrets
+     - `reusable-dev-standards-audit.yml` – **non-blocking** Hinweis-Audit (Prettier/EditorConfig/Husky/ESLint/Policy)
+     - `weekly-audit.yml` – Cron Mo 08:00, dispatcht `weekly-self-audit` in alle Repos. **Braucht `ORG_AUTOMATION_TOKEN`** (fine-grained PAT, minimaler Scope – siehe Header).
+   - **`claude-commands/`** – standardisierte Commands (per `sync-standards.sh` ausgerollt):
+     `aufräumen.md`, `pr-review.md` (mit GLOBAL-POLICY-Guardrails), `dependency-update.md`,
+     `security-review.md` (**global** unter `~/.claude/commands/`, cross-project Scan).
 
    > Hinweis: Die leeren Platzhalter-Configs früherer Stände sind durch echte, erprobte
    > Configs ersetzt. Das Legacy `automation-templates/.eslintrc.js` (alte `.eslintrc`-Form)

--- a/claude-commands/aufräumen.md
+++ b/claude-commands/aufräumen.md
@@ -1,0 +1,52 @@
+# Tagesabschluss: Aufräumen und Synchronisieren
+
+Führe den täglichen Cleanup-Workflow durch:
+
+## 1. Repository Status prüfen
+- Prüfe `git status` für uncommitted changes
+- Liste alle lokalen Branches
+- Prüfe ob lokaler main Branch mit origin synchron ist
+
+## 2. Branches aufräumen
+- Liste alle merged Feature Branches (lokal und remote)
+- Frage ob diese gelöscht werden sollen
+- Lösche approved Branches
+
+## 3. GitHub Actions Status
+- Liste letzte 5 Workflow Runs (Deploy, Tests, etc.)
+- Zeige Failed Runs falls vorhanden
+- Prüfe wichtige automatisierte Workflows
+
+## 4. Open Pull Requests
+- Liste alle offenen PRs
+- Zeige Status (Approved? Mergeable? CI passing?)
+- Weise auf alte PRs hin (>7 Tage)
+
+## 5. Issues Management
+- Liste Issues mit "Priority" oder "Bug" Label
+- Zeige kürzlich geschlossene Issues (heute)
+- Weise auf Issues ohne Label hin
+
+## 6. Dependencies & Security
+- Prüfe ob `package.json` Updates braucht (via npm outdated)
+- Prüfe auf Security Vulnerabilities (npm audit)
+- Zeige Warnungen falls vorhanden
+
+## 7. Data Status (falls relevant)
+- Prüfe letzte Aktualisierung von kritischen Daten-Files
+- Zeige ob Daten aktuell sind
+- Manuelles Update anbieten falls nötig
+
+## 8. Sync & Push
+- Pushe alle lokalen Commits
+- Hole neueste Änderungen von origin
+- Zeige finale Status-Zusammenfassung
+
+## 9. Zusammenfassung
+Erstelle eine kurze Zusammenfassung:
+- Anzahl gelöschter Branches
+- Anzahl gepushter Commits
+- Status der Environments (Production, Staging)
+- Daten-Aktualität (falls relevant)
+- Offene Issues/PRs
+- Nächste TODOs für morgen

--- a/claude-commands/dependency-update.md
+++ b/claude-commands/dependency-update.md
@@ -1,0 +1,226 @@
+# Dependency Update & Security Audit
+
+Sichere Aktualisierung von Dependencies mit Security-Checks
+
+## Ziel
+Dependencies aktualisieren, Security-Vulnerabilities fixen, Breaking Changes prüfen
+
+## Workflow
+
+### 1. Aktuellen Status analysieren
+- Zeige `npm outdated` Output
+- Gruppiere Updates nach Typ:
+  - **Patch Updates** (1.2.3 → 1.2.4) - Bugfixes, sicher
+  - **Minor Updates** (1.2.0 → 1.3.0) - Neue Features, meist kompatibel
+  - **Major Updates** (1.0.0 → 2.0.0) - Breaking Changes, Vorsicht!
+- Zeige Security Audit: `npm audit`
+- Priorisiere Security-relevante Updates
+
+### 2. Security Vulnerabilities fixen (PRIORITÄT!)
+- Zeige alle Vulnerabilities mit Severity (Critical, High, Medium, Low)
+- Für jede Vulnerability:
+  - Zeige betroffenes Package
+  - Zeige empfohlene Fix-Version
+  - Automatisch fixen falls möglich: `npm audit fix`
+  - Falls Breaking Change: Manuell fixen mit `npm install package@version`
+
+### 3. Patch & Minor Updates (meist sicher)
+- Frage: "Alle Patch/Minor Updates installieren? (empfohlen)"
+- Falls Ja:
+  ```bash
+  npm update  # Installiert alle Updates innerhalb semver range
+  ```
+- Falls Nein: Gehe durch einzelne Packages und frage jeweils
+
+### 4. Major Updates (Breaking Changes möglich)
+- Für jedes Major Update:
+  - Zeige Package-Name, alte Version, neue Version
+  - Suche nach CHANGELOG oder Breaking Changes:
+    - Check GitHub Releases: `gh repo view [package] --web`
+    - Check npm page für CHANGELOG
+  - Zeige Breaking Changes falls gefunden
+  - Frage: "Update installieren?"
+  - Falls Ja: `npm install package@latest`
+
+### 5. Dependencies Test-Run
+Nach jedem Update-Batch:
+- Führe `npm install` aus (um lock-file zu aktualisieren)
+- Führe Tests aus: `npm run test`
+- Führe Linting aus: `npm run lint`
+- Führe Type-Check aus: `npm run type-check` (falls TypeScript)
+- Führe Build aus: `npm run build`
+- Falls Fehler:
+  - Zeige Fehler
+  - Versuche zu fixen
+  - Falls nicht möglich: Rollback zu vorheriger Version
+
+### 6. Update-spezifische Fixes
+
+#### TypeScript Major Update
+- Prüfe `tsconfig.json` für deprecated Options
+- Aktualisiere `@types/*` Packages
+- Prüfe auf neue strict Checks
+
+#### React/React Native Major Update
+- Prüfe auf deprecated APIs
+- Aktualisiere React-Plugins (babel, etc.)
+- Teste App vollständig
+
+#### Expo Major Update
+- Folge Expo Upgrade Guide: `npx expo upgrade`
+- Prüfe `app.json` für neue Config-Optionen
+- Teste auf realen Devices
+
+#### Build Tools (Webpack, Vite, etc.)
+- Prüfe Config-Files für Breaking Changes
+- Teste Build-Output
+- Prüfe Bundle-Size
+
+### 7. Lock-File aktualisieren
+- Stelle sicher dass `package-lock.json` committed wird
+- Prüfe auf ungewollte Dependency-Änderungen:
+  ```bash
+  git diff package-lock.json
+  ```
+- Falls zu viele Änderungen: Nutze `npm ci` statt `npm install` für sauberen State
+
+### 8. Dokumentation
+- Aktualisiere CHANGELOG.md:
+  ```markdown
+  ## [Version] - YYYY-MM-DD
+  ### Dependencies
+  - Updated [package] from X.Y.Z to A.B.C
+  - Fixed security vulnerability in [package]
+  ```
+- Falls Major Updates: Dokumentiere Breaking Changes
+- Aktualisiere README falls Versions-Anforderungen ändern (z.B. Node.js Version)
+
+### 9. Commit & PR erstellen
+- Erstelle Feature-Branch: `git checkout -b chore/dependency-update-[YYYY-MM-DD]`
+- Commit Änderungen:
+  ```bash
+  git add package.json package-lock.json CHANGELOG.md
+  git commit -m "chore: Update dependencies and fix security vulnerabilities"
+  ```
+- Erstelle PR:
+  ```bash
+  gh pr create --base testing --title "chore: Dependency Update [Date]" --body "$(cat <<EOF
+  ## Dependency Updates
+
+  ### Security Fixes
+  - [Package]: [Old] → [New] (Fixes CVE-XXXX)
+
+  ### Major Updates
+  - [Package]: [Old] → [New]
+    - Breaking Changes: [Liste]
+
+  ### Minor/Patch Updates
+  - [Package]: [Old] → [New]
+
+  ## Testing
+  - [x] Tests passing
+  - [x] Build successful
+  - [x] Type-check passing
+  - [x] Linting passing
+
+  ## Impact
+  [Beschreibung der Auswirkungen]
+  EOF
+  )"
+  ```
+
+### 10. Post-Update Monitoring
+- Teste App gründlich (manuell und automatisiert)
+- Achte auf Performance-Regression
+- Monitore Error-Logs nach Deployment
+- Falls Probleme: Schnelles Rollback vorbereiten
+
+## Sicherheitschecks
+
+**KRITISCH - Besondere Vorsicht bei:**
+- ❌ Major Updates von Core-Dependencies (React, TypeScript, etc.)
+- ❌ Updates die `node_modules` Struktur stark ändern
+- ❌ Dependencies mit vielen Downstream-Dependencies
+- ❌ Critical Security Fixes die Breaking Changes enthalten
+
+**Immer testen:**
+- ✅ Vollständiger Test-Suite Durchlauf
+- ✅ Build erfolgreich
+- ✅ App startet und funktioniert
+- ✅ Keine neuen Console-Errors
+
+## Rollback-Strategie
+
+Falls nach Update Probleme auftreten:
+```bash
+# Rollback zu vorheriger Version
+git checkout HEAD~1 package.json package-lock.json
+npm ci  # Installiert exakt die Versionen aus lock-file
+npm run test && npm run build
+
+# Falls erfolgreich
+git add package.json package-lock.json
+git commit -m "revert: Rollback dependency update due to [reason]"
+```
+
+## Automatisierung (Optional)
+
+### Dependabot Configuration
+Erstelle `.github/dependabot.yml`:
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    reviewers:
+      - "your-username"
+    labels:
+      - "dependencies"
+      - "automated"
+    # Gruppiere Minor/Patch Updates
+    groups:
+      development-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+```
+
+### Renovate (Alternative zu Dependabot)
+- Mehr Konfigurationsmöglichkeiten
+- Automatische Merge für Patch-Updates möglich
+- Bessere Gruppierung von Updates
+
+## Best Practices
+
+✅ **Do:**
+- Regelmäßig updaten (mindestens monatlich)
+- Security-Updates sofort anwenden
+- CHANGELOG dokumentieren
+- Gründlich testen nach Updates
+- Lock-Files committen
+
+❌ **Don't:**
+- Nicht alle Updates blind installieren
+- Nicht ohne Tests updaten
+- Nicht Major Updates kurz vor Release
+- Nicht mehrere Major Updates gleichzeitig
+- Nicht Lock-Files ignorieren
+
+## Checkliste
+
+- [ ] `npm outdated` analysiert
+- [ ] `npm audit` geprüft
+- [ ] Security Vulnerabilities gefixt
+- [ ] Patch/Minor Updates installiert
+- [ ] Major Updates einzeln geprüft
+- [ ] Tests laufen durch
+- [ ] Build erfolgreich
+- [ ] Type-Check (falls TS) bestanden
+- [ ] CHANGELOG aktualisiert
+- [ ] PR erstellt und reviewed
+- [ ] App getestet (dev environment)
+- [ ] Keine neuen Errors/Warnings

--- a/claude-commands/pr-review.md
+++ b/claude-commands/pr-review.md
@@ -1,0 +1,131 @@
+# Pull Request Review & Merge
+
+Automatisierter PR-Review-Workflow: Prüfen, Suggestions umsetzen, Mergen
+
+> **[GLOBAL POLICY] – verbindlich (Issue #7):**
+> - PRs immer gegen `testing`, nie direkt gegen `staging` oder `main`
+> - **Merge auf `main` nur mit expliziter schriftlicher Freigabe** – niemals eigenständig
+> - `--delete-branch` nur für Feature-Branches (nie `staging`/`testing`)
+> - `--no-verify` nur auf explizite Bitte
+> - Vor Merge immer Copilot-Suggestions abwarten und prüfen
+
+## Ziel
+Einen Pull Request gründlich prüfen, Code-Review-Suggestions umsetzen und für Merge vorbereiten.
+
+## Workflow
+
+### 1. PR Status prüfen
+- Zeige PR-Details (Titel, Beschreibung, Files Changed)
+- Prüfe ob PR-Ziel-Branch aktuell ist mit main/staging
+- Falls outdated: Frage ob Target-Branch in PR-Branch gemergt werden soll
+- Prüfe CI/CD Status (Tests, Linting, Build)
+- Zeige offene Review-Comments
+
+### 2. Code Review durchführen
+- Zeige alle Changed Files
+- Prüfe auf häufige Probleme:
+  - Hardcodierte Strings (sollten i18n nutzen)
+  - Console.log Statements
+  - Fehlende Error Handling
+  - Code-Duplikation
+  - Fehlende Tests für neue Features
+  - Breaking Changes ohne CHANGELOG Update
+  - Versions-Inkonsistenz (package.json vs app.json)
+
+### 3. Review-Suggestions umsetzen
+- Liste alle offenen Review-Comments
+- Für jeden Comment:
+  - Zeige Context (File, Line, Comment)
+  - Frage ob Suggestion umgesetzt werden soll
+  - Setze Änderung um
+  - Markiere Comment als "Resolved"
+
+### 4. Tests & Validierung
+- Führe Tests aus: `npm run test`
+- Führe Linting aus: `npm run lint`
+- Führe Type-Check aus: `npm run type-check` (falls TypeScript)
+- Prüfe Build: `npm run build`
+- Falls Fehler: Zeige Fehler und biete Fixes an
+
+### 5. CHANGELOG & Dokumentation
+- Prüfe ob CHANGELOG.md aktualisiert wurde
+- Falls neue Features/Breaking Changes: Schlage CHANGELOG-Eintrag vor
+- Prüfe ob README/Docs aktualisiert werden müssen
+
+### 6. Merge vorbereiten
+- Prüfe ob alle Checks grün sind
+- Prüfe ob mindestens 1 Approval vorhanden (falls erforderlich)
+- Zeige Merge-Status (Ready to merge? Conflicts?)
+- Falls Konflikte: Zeige betroffene Files
+
+### 7. Merge durchführen (nur wenn bestätigt)
+**WICHTIG:** Vor Merge nochmal bestätigen lassen!
+
+- Merge-Strategie wählen:
+  - **Squash Merge** (empfohlen für Feature-Branches)
+  - **Merge Commit** (für Release-Branches)
+  - **Rebase Merge** (für saubere Historie)
+- PR mergen via `gh pr merge [PR-Number] --[strategy]`
+- Feature-Branch löschen (lokal und remote)
+- Ausgabe: "✅ PR #XX successfully merged and branch deleted"
+
+### 8. Post-Merge Cleanup
+- Checkout zurück zu main/staging/testing
+- Pull neueste Änderungen
+- Zeige nächste offene PRs (falls vorhanden)
+
+## Fehlerbehandlung
+
+### CI/CD Fails
+- Zeige Fehler-Log
+- Biete Fixes für häufige Probleme:
+  - Test Failures → Zeige failed Tests, biete Fixes
+  - Linting Errors → Auto-fix via `npm run lint -- --fix`
+  - Build Errors → Zeige Fehler, analysiere Ursache
+
+### Merge Conflicts
+- Zeige betroffene Files
+- Biete manuelle Resolution an:
+  ```bash
+  git checkout [pr-branch]
+  git merge [target-branch]
+  # Resolve conflicts manually
+  git add .
+  git commit -m "Resolve merge conflicts"
+  git push
+  ```
+
+### Outdated Target Branch
+- Empfehlung: Target-Branch in PR-Branch mergen
+  ```bash
+  git checkout [pr-branch]
+  git merge origin/[target-branch]
+  git push
+  ```
+
+## Sicherheitschecks
+
+**KRITISCH - NIEMALS automatisch mergen wenn:**
+- ❌ CI/CD Tests fehlgeschlagen
+- ❌ Merge Conflicts vorhanden
+- ❌ Keine Approvals (falls erforderlich)
+- ❌ Target-Branch ist `main` oder `production` (extra Vorsicht!)
+
+**Immer fragen vor:**
+- Breaking Changes
+- Dependency Updates (major versions)
+- Konfigurationsänderungen (.github/, .env, etc.)
+
+## Best Practices
+
+✅ **Do:**
+- Gründlich prüfen vor Merge
+- Alle Review-Suggestions durchgehen
+- Tests lokal laufen lassen
+- CHANGELOG aktualisieren
+
+❌ **Don't:**
+- Nicht blind auto-mergen
+- Nicht ohne Tests mergen
+- Nicht direkt zu `main` mergen (außer Hotfixes)
+- Nicht alte PRs mergen ohne Re-Review

--- a/claude-commands/security-review.md
+++ b/claude-commands/security-review.md
@@ -1,0 +1,58 @@
+# Security Review (Cross-Project)
+
+Globaler Security-Scan über alle lokalen Projekte mit konsolidiertem Report (Issue #7).
+
+> **Ablageort:** global unter `~/.claude/commands/security-review.md`, nicht pro Projekt.
+> Begründung: scannt projektübergreifend, gehört nicht in ein einzelnes Repo.
+
+## Ziel
+Alle lokalen Projekt-Repositories auf Secrets, Fingerprints, getrackte sensible Dateien
+und Gitignore-Lücken prüfen – ein zusammengefasster Bericht statt sieben Einzelläufe.
+
+## Workflow
+
+### 1. Projekte ermitteln
+- Bestimme die zu prüfenden Repos (Standard: alle App-Projekte im Workspace).
+- Pro Repo: ist es ein Git-Repo? Aktueller Branch? Uncommitted Changes?
+
+### 2. Pro Projekt scannen
+Für jedes Repo dieselben Checks (entsprechen `reusable-security-scan.yml`):
+
+- **Signing-Fingerprints** (SHA1/SHA256 Colon-Hex):
+  ```bash
+  git -C "$repo" grep -nE '([0-9A-Fa-f]{2}:){15,}[0-9A-Fa-f]{2}' -- . ':!*.lock'
+  ```
+- **Hardcodierte API-Keys / Tokens:**
+  ```bash
+  git -C "$repo" grep -niE '(api[_-]?key|secret[_-]?key|auth[_-]?token|access[_-]?token)["'\'' ]*[:=]["'\'' ]*[A-Za-z0-9_-]{16,}' -- . ':!*.lock'
+  ```
+- **Getrackte sensible Dateien:**
+  ```bash
+  git -C "$repo" ls-files | grep -E '(credentials\.json$|\.jks$|\.keystore$|\.p12$|\.p8$|^\.env)'
+  ```
+- **Gitignore-Pflichteinträge** vorhanden? (`.env`, `credentials.json`, `*.jks`, `*.keystore`, `docs/private/`)
+- **`docs/private/` nicht getrackt?**
+- **`npm audit`** (falls `package.json` vorhanden) – Vulnerabilities zählen.
+
+### 3. Befunde einordnen
+- Bekannte False Positives kennzeichnen (z.B. CrUX-Demo-Key in `@react-native/debugger-frontend`).
+- Severity zuordnen: 🔴 Secret/Fingerprint getrackt · 🟡 Gitignore-Lücke · 🟢 nur Hinweis.
+
+### 4. Konsolidierter Report
+Tabelle über alle Projekte:
+
+| Projekt | Fingerprints | Secrets | Sensible Dateien | Gitignore | npm audit |
+|---|---|---|---|---|---|
+| ... | ✅/❌ | ✅/❌ | ✅/❌ | ✅/⚠️ | 0 / N |
+
+- Anschließend priorisierte Handlungsempfehlungen (kritischste zuerst).
+- Nichts automatisch ändern – nur berichten und Fixes vorschlagen.
+
+## Sicherheitschecks
+- **Niemals** gefundene Secrets im Klartext in Commits/Issues/Logs ausgeben – nur Datei + Zeile.
+- Bei echtem Leak: sofort als kritisch markieren, Rotation + History-Bereinigung empfehlen.
+
+## Best Practices
+✅ Regelmäßig laufen lassen (z.B. wöchentlich, ergänzend zu `weekly-audit.yml`).
+✅ Public-Repos strenger behandeln (alle Workspace-Projekte sind öffentlich).
+❌ Keine destruktiven Aktionen ohne Rückfrage (kein `git filter-repo` etc. automatisch).


### PR DESCRIPTION
**Issue #7 Teil 2.** Stacked auf #9 (Base = `feature/issue-7-dev-standards-scripts`) – nach Merge von #9 auf `main` umbasen.

Closes Teil 2 von #7.

## Reusable Workflows (immer `@v1` aufrufen, nie `@main`)
- **`reusable-ci-quality.yml`** – konfigurierbar: lint / type-check / test, Node-Version, Commands per Input
- **`reusable-gitignore-audit.yml`** – **BLOCKING** (alle Repos öffentlich, Punkt 7): Pflicht-Ignores + keine getrackten Secrets / `docs/private`
- **`reusable-dev-standards-audit.yml`** – **non-blocking** Hinweis-Audit (Prettier/EditorConfig/Husky/ESLint-FlatConfig/GLOBAL POLICY)
- **`weekly-audit.yml`** – Cron Mo 08:00, dispatcht `weekly-self-audit` in alle Repos
  - nutzt **`ORG_AUTOMATION_TOKEN`** (fine-grained PAT, minimaler Scope – Punkt 6)
  - failt früh mit klarer Fehlermeldung, wenn das Token fehlt (statt still ins Leere)

## Claude Commands (`claude-commands/`)
- `aufräumen.md`, `dependency-update.md` – aus erprobten Vorlagen übernommen
- `pr-review.md` – **mit GLOBAL-POLICY-Guardrails** im Header (kein Auto-Merge auf main etc.)
- `security-review.md` – **NEU, global** (`~/.claude/commands/`): cross-project Security-Scan mit konsolidiertem Report

`scripts/sync-standards.sh` (aus #9) rollt diese Commands automatisch aus – verifiziert.

## Tests
- YAML-Validierung aller 4 Workflows (python yaml.safe_load) ✅
- sync-standards.sh kopiert alle 4 Commands inkl. Policy-Header ✅

## Offene Folge-Punkte
- `ORG_AUTOMATION_TOKEN` als Repo-Secret anlegen + `repository_dispatch`-Listener in Ziel-Repos (separat)
- `@v1`-Tag setzen, sobald #9 + dieser PR auf `main` sind

🤖 Generated with [Claude Code](https://claude.com/claude-code)