### PR TITLE
fix(#7): Audit-Verfeinerungen aus Pilot (env-Config + Fingerprint-Check)

### DIFF
--- a/.github/workflows/reusable-gitignore-audit.yml
+++ b/.github/workflows/reusable-gitignore-audit.yml
@@ -39,11 +39,13 @@ jobs:
             exit 1
           fi
 
-          # Pflicht-Einträge (Issue #7) – deckungsgleich mit den geprüften
-          # sensiblen Dateitypen weiter unten (.env*, credentials, keystores).
+          # Pflicht-Einträge (Issue #7). Nur konventionell-geheime Dateien.
+          # Bewusst NICHT .env.* gefordert: committete .env.<environment> mit
+          # ausschließlich PUBLIC-Config (EXPO_PUBLIC_*, NODE_ENV) sind ein
+          # legitimes Muster. Geheime Werte fängt der Content-Scan separat ab.
           required=(
             ".env"
-            ".env.*"
+            ".env.local"
             "credentials.json"
             "*.jks"
             "*.keystore"
@@ -59,8 +61,11 @@ jobs:
           done
 
           # Sensible Dateien dürfen NICHT getrackt sein (öffentliches Repo!)
-          if git ls-files | grep -E '(^|/)(\.env(\..+)?$|credentials\.json$|.*\.jks$|.*\.keystore$|.*\.p12$|.*\.p8$)'; then
-            echo "::error title=Sensible Datei getrackt::credentials/keystore/env im öffentlichen Repo"
+          # .env-Erkennung: nur die konventionell-geheimen (.env, .env.local,
+          # .env.<env>.local) – NICHT committete .env.<environment>-Config.
+          if git ls-files \
+               | grep -E '(^|/)(\.env(\.local)?$|\.env\.[^/]*\.local$|credentials\.json$|.*\.jks$|.*\.keystore$|.*\.p12$|.*\.p8$)'; then
+            echo "::error title=Sensible Datei getrackt::credentials/keystore/secret-env im öffentlichen Repo"
             problems=1
           fi
 

--- a/.github/workflows/reusable-gitignore-audit.yml
+++ b/.github/workflows/reusable-gitignore-audit.yml
@@ -69,6 +69,27 @@ jobs:
             problems=1
           fi
 
+          # Committete .env.<environment> dürfen NUR Public-Config enthalten.
+          # Allowlist der erlaubten Variablennamen erzwingen, damit kein Geheimnis
+          # (DATABASE_URL, SENTRY_DSN, …) unbemerkt im öffentlichen Repo landet.
+          allow_re='^(EXPO_PUBLIC_[A-Z0-9_]+|EXPO_ENV|NODE_ENV)='
+          while IFS= read -r envfile; do
+            [ -n "$envfile" ] || continue
+            # Nur echte Environment-Config-Dateien (.env.<env>), keine secret-Varianten
+            case "$envfile" in
+              *.local) continue ;;
+            esac
+            while IFS= read -r line; do
+              # Kommentare und Leerzeilen ignorieren
+              case "$line" in ''|\#*) continue ;; esac
+              if ! printf '%s\n' "$line" | grep -Eq "$allow_re"; then
+                varname="${line%%=*}"
+                echo "::error title=Nicht erlaubte env-Variable::'$varname' in $envfile – committete .env.<environment> dürfen nur EXPO_PUBLIC_*, EXPO_ENV, NODE_ENV enthalten"
+                problems=1
+              fi
+            done < "$envfile"
+          done < <(git ls-files | grep -E '(^|/)\.env\.[^/]+$' | grep -Ev '\.local$')
+
           # docs/private/ darf nicht getrackt sein
           if git ls-files | grep -E '^docs/private/'; then
             echo "::error title=docs/private getrackt::Interne Docs dürfen nicht im Repo sein"

--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -55,10 +55,11 @@ jobs:
             fi
           }
 
-          echo "::group::Signing fingerprints (SHA1/SHA256 colon-hex)"
-          grep_scan "Signing fingerprint" \
-            -nE '([0-9A-Fa-f]{2}:){15,}[0-9A-Fa-f]{2}' -- . ':!*.lock' ':!**/node_modules/**'
-          echo "::endgroup::"
+          # Hinweis: Kein Fingerprint-Check im CI-Scan. SHA1/SHA256-Fingerprints
+          # sind öffentliche Hashes (kein Geheimnis) und werden teils bewusst in
+          # Docs dokumentiert (z.B. BUILD.md). Das Geheimnis ist die .jks/.keystore
+          # selbst – die deckt der Sensitive-File-Check ab. Wer staged Fingerprints
+          # lokal blocken will, nutzt den Pre-Commit-Hook (dev-standards/base).
 
           echo "::group::Hardcoded API keys / tokens"
           grep_scan "Hardcoded secret" \

--- a/claude-commands/security-review.md
+++ b/claude-commands/security-review.md
@@ -26,11 +26,11 @@ Für jedes Repo dieselben Checks (entsprechen `reusable-security-scan.yml`):
   ```bash
   git -C "$repo" grep -niE '(api[_-]?key|secret[_-]?key|auth[_-]?token|access[_-]?token)["'\'' ]*[:=]["'\'' ]*[A-Za-z0-9_-]{16,}' -- . ':!*.lock'
   ```
-- **Getrackte sensible Dateien:**
+- **Getrackte sensible Dateien:** (nur konventionell-geheime .env – nicht committete `.env.<environment>`-Config)
   ```bash
-  git -C "$repo" ls-files | grep -E '(credentials\.json$|\.jks$|\.keystore$|\.p12$|\.p8$|^\.env)'
+  git -C "$repo" ls-files | grep -E '(credentials\.json$|\.jks$|\.keystore$|\.p12$|\.p8$|(^|/)\.env(\.local)?$|(^|/)\.env\..*\.local$)'
   ```
-- **Gitignore-Pflichteinträge** vorhanden? (`.env`, `.env.*`, `credentials.json`, `*.jks`, `*.keystore`, `*.p12`, `*.p8`, `docs/private/`) – deckungsgleich mit `reusable-gitignore-audit.yml`
+- **Gitignore-Pflichteinträge** vorhanden? (`.env`, `.env.local`, `credentials.json`, `*.jks`, `*.keystore`, `*.p12`, `*.p8`, `docs/private/`) – deckungsgleich mit `reusable-gitignore-audit.yml`. `.env.<environment>` mit reiner Public-Config ist erlaubt.
 - **`docs/private/` nicht getrackt?**
 - **`npm audit`** (falls `package.json` vorhanden) – Vulnerabilities zählen.
 

--- a/claude-commands/security-review.md
+++ b/claude-commands/security-review.md
@@ -28,7 +28,7 @@ Für jedes Repo dieselben Checks (entsprechen `reusable-security-scan.yml`):
   ```
 - **Getrackte sensible Dateien:** (nur konventionell-geheime .env – nicht committete `.env.<environment>`-Config)
   ```bash
-  git -C "$repo" ls-files | grep -E '(credentials\.json$|\.jks$|\.keystore$|\.p12$|\.p8$|(^|/)\.env(\.local)?$|(^|/)\.env\..*\.local$)'
+  git -C "$repo" ls-files | grep -E '(credentials\.json$|\.jks$|\.keystore$|\.p12$|\.p8$|(^|/)\.env(\.local)?$|(^|/)\.env\.[^/]*\.local$)'
   ```
 - **Gitignore-Pflichteinträge** vorhanden? (`.env`, `.env.local`, `credentials.json`, `*.jks`, `*.keystore`, `*.p12`, `*.p8`, `docs/private/`) – deckungsgleich mit `reusable-gitignore-audit.yml`. `.env.<environment>` mit reiner Public-Config ist erlaubt.
 - **`docs/private/` nicht getrackt?**


### PR DESCRIPTION
Zwei Korrekturen, beim Pilot-Rollout des `weekly-self-audit`-Listeners in **EnergyPriceGermany** entdeckt.

## 1. gitignore-audit: committete `.env.<environment>` Public-Config erlauben
Das blocking `reusable-gitignore-audit.yml` (aus #11) wertete **jedes** getrackte `.env.*` als Secret-Verstoß. EnergyPriceGermany committet aber bewusst `.env.production/.staging/.testing` mit **ausschließlich Public-Config** (`EXPO_PUBLIC_*`, `EXPO_ENV`, `NODE_ENV`).
- Sensible-Datei-Regex blockt nur `.env` / `.env.local` / `.env.<env>.local` – nicht committete `.env.<environment>`-Config
- Pflicht-Einträge: `.env.*` → `.env.local`
- Geheime Werte fängt weiterhin der Content-Scan ab
- `security-review.md` synchron nachgezogen

## 2. security-scan: Fingerprint-Check entfernt
Der Scan flaggte die in `docs/BUILD.md` dokumentierten **öffentlichen** Keystore-Fingerprints (SHA1/SHA256). Fingerprints sind öffentliche Hashes, kein Geheimnis – das Geheimnis ist die `.jks`/`.keystore`-Datei (deckt der Sensitive-File-Check ab). Lokales Blocken staged Fingerprints bleibt über den Pre-Commit-Hook möglich.

## Getestet
Gegen reale EnergyPriceGermany-Dateiliste: gitignore-audit + security-scan würden jetzt **grün** laufen.

## Wichtig danach
`v1`-Tag auf diesen Fix nachziehen, damit `@v1`-Konsumenten (Pilot EnergyPrice) die korrigierte Version bekommen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)