### PR TITLE
fix(security-scan): set -e killt grep_scan bei rc=1 (kein Treffer)

### DIFF
--- a/.github/workflows/reusable-security-scan.yml
+++ b/.github/workflows/reusable-security-scan.yml
@@ -40,8 +40,11 @@ jobs:
           # Echte Fehler brechen hart ab (fail-closed), statt als "keine" durchzurutschen.
           grep_scan() { # $1=Titel  $2..=git-grep-Argumente
             local title="$1"; shift
-            local out rc
-            out="$(git grep "$@" 2>&1)"; rc=$?
+            local out rc=0
+            # set -e: 'out=$(...); rc=$?' bricht bei git-grep rc=1 (= kein Treffer,
+            # der Normalfall) schon an der Zuweisung ab, bevor rc gesetzt wird.
+            # '|| rc=$?' fängt den non-zero ab, damit rc=1 als "sauber" durchläuft.
+            out="$(git grep "$@" 2>&1)" || rc=$?
             if [ "$rc" -eq 0 ]; then
               echo "::error title=$title::Fund im Repo"
               printf '%s\n' "$out"


### PR DESCRIPTION
## Problem

Der zentrale `reusable-security-scan.yml` failt auf **jedem sauberen Repo**.

Unter `set -euo pipefail` (Job-Default) bricht
```bash
out="$(git grep "$@" 2>&1)"; rc=$?
```
schon an der Zuweisung ab, sobald `git grep` `rc=1` (= **kein Treffer**, der Normalfall) liefert. `rc=$?` wird nie erreicht → errexit beendet das Script. Im Log sichtbar als: Gruppe `Hardcoded API keys / tokens` öffnet, dann sofort `exit 1` – ohne `keine`/`endgroup`.

## Fix

```bash
local out rc=0
out="$(git grep "$@" 2>&1)" || rc=$?
```

- `rc=0` (Fund) → fail-closed, unverändert
- `rc>=2` (echter Scanner-Fehler) → fail-closed, unverändert
- `rc=1` (sauber) → läuft jetzt korrekt als "keine" durch

## Kontext

Entdeckt im Cross-Project-Pilot ([Energy_Price_Germany#315](https://github.com/S540d/Energy_Price_Germany/issues/315) / #7). Nach der Public-Schaltung von project-templates (entsperrt den Reusable-Workflow-Zugriff für das öffentliche Consumer-Repo) liefen `dev-standards-audit` und `gitignore-audit` grün – `security-scan` war der einzige rote Job, Ursache war dieser `set -e`-Bug, **kein** echter Fund.

Reproduziert + Fix verifiziert gegen den PR-Merge-Tree von Energy_Price_Germany (rc=1 → "keine", findings=0).

## Nach Merge

`v1`/`v1.0.x` Tags müssen nachgezogen werden, damit die Consumer (`@v1`) den Fix bekommen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)