### PR TITLE
ci: PR-Review + review-gate + protect-main Ruleset für project-templates (Issue #16)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,23 @@
+name: PR Review (Claude)
+
+# Automatischer Code-Review via Anthropic API bei jedem PR.
+# Voraussetzung: ANTHROPIC_API_KEY als Repository- oder Org-Secret gesetzt.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  contents: read
+  statuses: write
+
+jobs:
+  pr-review:
+    uses: S540d/project-templates/.github/workflows/reusable-pr-review.yml@v1
+    secrets:
+      anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+    with:
+      language: 'de'
+      # model: 'claude-sonnet-4-6'            # tiefere Analyse (default)
+      # model: 'claude-haiku-4-5-20251001'    # schnell + günstig

--- a/.github/workflows/review-gate-resolve.yml
+++ b/.github/workflows/review-gate-resolve.yml
@@ -1,0 +1,17 @@
+name: Review Gate Resolve
+
+# Setzt den Commit-Status "review-gate" je nachdem, ob das Quittierungs-Label
+# gesetzt ist. Reagiert auf labeled/unlabeled, damit das Gate sofort umspringt,
+# ohne neuen Commit. Siehe reusable-pr-review.yml (Gate-Erzeugung).
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+
+permissions:
+  statuses: write
+  pull-requests: read
+
+jobs:
+  resolve:
+    uses: S540d/project-templates/.github/workflows/reusable-review-gate-resolve.yml@v1


### PR DESCRIPTION
## Was & Warum

project-templates ist das einzige Repo ohne eigenes \`protect-main\`-Ruleset und ohne Self-PR-Review (Issue #16, letzter offener Punkt).

## Änderungen

- \`.github/workflows/pr-review.yml\` — ruft \`reusable-pr-review.yml@v1\` auf sich selbst auf (Self-Call)
- \`.github/workflows/review-gate-resolve.yml\` — Label-Gate analog zu allen anderen Repos

## Noch separat erledigt (nach Merge)

- \`protect-main\`-Ruleset via API anlegen (branches: \`main\` + \`testing\`, required check: \`review-gate\`)

## Test plan

- [ ] PR-Review läuft durch (review-gate setzt Status)
- [ ] Label `suggestions gelesen und verstanden` entsperrt den Merge
- [ ] Nach Merge: Ruleset anlegen, Merge testing→main verifizieren

🤖 Generated with [Claude Code](https://claude.com/claude-code)