### PR TITLE
fix: --admin im testing→main Merge-Befehl (pr-review.md)

### DIFF
--- a/claude-commands/pr-review.md
+++ b/claude-commands/pr-review.md
@@ -89,7 +89,7 @@ Bei Findings:
   **1 Approval** verlangt. Als Solo-Dev kann man den eigenen PR nicht approven →
   dieser eine Block ist nur per Admin-Bypass lösbar. Das ist der **bewusste
   manuelle Release-Schritt**, NICHT mit dem `review-gate` zu verwechseln.
-- Merge: `gh pr merge <nr> --squash` (kein `--delete-branch` für langlebige Branches!)
+- Merge: `gh pr merge <nr> --squash --admin` (kein `--delete-branch` für langlebige Branches!)
 - **Nur mit expliziter schriftlicher Freigabe** (siehe GLOBAL POLICY oben).
 
 ### 9. Post-Merge Cleanup


### PR DESCRIPTION
## Was

Im Standard-Command `claude-commands/pr-review.md` zeigte der Code-Block für den
Sonderfall `testing → main`:

\`\`\`
gh pr merge <nr> --squash
\`\`\`

…obwohl der umgebende Text den nötigen `--admin`-Bypass beschreibt. Jetzt:

\`\`\`
gh pr merge <nr> --squash --admin
\`\`\`

## Warum

Finding aus den Issue-#31-PRs (Claude-Review): Der fehlende `--admin` im Code-Block
könnte beim Copy-Paste vergessen werden. Quelle korrigiert → wird in alle Repos ausgerollt.