### PR TITLE
fix: Command-Findings aus PR-Reviews beheben

### DIFF
--- a/claude-commands/aufräumen.md
+++ b/claude-commands/aufräumen.md
@@ -38,8 +38,9 @@ Führe den täglichen Cleanup-Workflow durch:
 - Manuelles Update anbieten falls nötig
 
 ## 8. Sync & Push
-- Pushe alle lokalen Commits
-- Hole neueste Änderungen von origin
+- Zeige alle lokalen Commits, die noch nicht gepusht sind (`git log @{u}..HEAD`)
+- **Frage vor Push:** "Soll ich diese Commits jetzt pushen?" — nie automatisch pushen
+- Falls Ja: pushe und hole neueste Änderungen von origin
 - Zeige finale Status-Zusammenfassung
 
 ## 9. Zusammenfassung

--- a/claude-commands/dependency-update.md
+++ b/claude-commands/dependency-update.md
@@ -1,6 +1,7 @@
-# Dependency Update & Security Audit
+# Dependency Update & Security Audit (npm/yarn/pnpm)
 
-Sichere Aktualisierung von Dependencies mit Security-Checks
+Sichere Aktualisierung von Dependencies mit Security-Checks.
+Paketmanager: npm (Standard), yarn oder pnpm – Befehle ggf. anpassen.
 
 ## Ziel
 Dependencies aktualisieren, Security-Vulnerabilities fixen, Breaking Changes prüfen
@@ -36,8 +37,8 @@ Dependencies aktualisieren, Security-Vulnerabilities fixen, Breaking Changes pr�
 - Für jedes Major Update:
   - Zeige Package-Name, alte Version, neue Version
   - Suche nach CHANGELOG oder Breaking Changes:
-    - Check GitHub Releases: `gh repo view [package] --web`
-    - Check npm page für CHANGELOG
+    - Check npm page: `npm show <package> homepage` oder Suche auf npmjs.com
+    - Check GitHub Releases des jeweiligen Repos (URL aus `npm show <package> repository.url`)
   - Zeige Breaking Changes falls gefunden
   - Frage: "Update installieren?"
   - Falls Ja: `npm install package@latest`

--- a/claude-commands/pr-review.md
+++ b/claude-commands/pr-review.md
@@ -16,7 +16,7 @@ Einen Pull Request gründlich prüfen, Code-Review-Suggestions umsetzen und für
 
 ### 1. PR Status prüfen
 - Zeige PR-Details (Titel, Beschreibung, Files Changed)
-- Prüfe ob PR-Ziel-Branch aktuell ist mit main/staging
+- Prüfe ob PR-Ziel-Branch aktuell ist mit main (kein staging – GLOBAL POLICY)
 - Falls outdated: Frage ob Target-Branch in PR-Branch gemergt werden soll
 - Prüfe CI/CD Status (Tests, Linting, Build)
 - Zeige offene Review-Comments


### PR DESCRIPTION
## Was

Vier offene Findings aus den review-gate-Comments der Issue-#31-PRs behoben.

## Änderungen

**`dependency-update.md`**
- Titel/Ziel: npm-only-Scope explizit gemacht, yarn/pnpm als Alternativen erwähnt
- `gh repo view [package] --web` → `npm show <package> homepage` (kein unaufgelöster Platzhalter)

**`aufräumen.md`**
- Schritt 8: Confirmation-Gate vor Push ergänzt (`git log @{u}..HEAD` + explizite Frage) — nie automatisch pushen

**`pr-review.md`**
- "main/staging" → "main (kein staging – GLOBAL POLICY)" — konsistent mit der GLOBAL POLICY oben im selben Dokument

## Hintergrund

Alle vier Findings waren inhaltliche Korrekturen an den Quell-Templates, die anschließend in alle 5 App-Repos synchronisiert werden.