### PR TITLE
fix: --admin in README-Befehl + LICENSE-Jahr 2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 Creative Commons Attribution-NonCommercial 4.0 International
 
-Copyright (c) 2025 DevSven (S540d)
+Copyright (c) 2026 DevSven (S540d)
 
 You are free to:
   Share — copy and redistribute the material in any medium or format

--- a/README.md
+++ b/README.md
@@ -60,8 +60,7 @@ feature/issue-XXX → testing → main
 
 - PRs immer gegen `testing` (nie direkt `main`)
 - Merge feature→testing: `gh pr merge --squash --delete-branch`
-- Merge testing→main: `gh pr merge --squash` (kein `--delete-branch`!)
-- main braucht `--admin`
+- Merge testing→main: `gh pr merge --squash --admin` (kein `--delete-branch`!)
 
 Vollständig dokumentiert in `dev-standards/global-policy.md`.
 


### PR DESCRIPTION
## Summary

Zwei kleine Korrekturen aus dem Code-Review von PR #38:

- **README.md**: `gh pr merge --squash --admin` jetzt inline im testing→main-Befehl statt als separater Stichpunkt — verhindert, dass `--admin` übersehen wird
- **LICENSE**: Jahreszahl von 2025 auf 2026 korrigiert

## Test plan

- [ ] README Branch-Strategie-Abschnitt geprüft
- [ ] LICENSE-Jahr stimmt

---
_Generated by [Claude Code](https://claude.ai/code/session_01SRoU9ZYPP5mCRVEtgqAEm9)_