### PR TITLE
fix: reusable-pr-review @v1 – secrets-Kontext aus step-if heben

### DIFF
--- a/.github/workflows/reusable-pr-review.yml
+++ b/.github/workflows/reusable-pr-review.yml
@@ -93,6 +93,10 @@ jobs:
       github.event_name == 'pull_request' &&
       inputs.autofix &&
       github.event.pull_request.head.repo.fork == false
+    env:
+      # secrets-Kontext ist in einem step-level if: nicht erlaubt -> auf Job-Ebene
+      # in env heben (dort zulässig) und im step auf den abgeleiteten Wert prüfen.
+      HAS_API_KEY: ${{ secrets.anthropic_api_key != '' }}
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4
@@ -103,7 +107,7 @@ jobs:
       - name: Claude autofix
         # Ohne API-Key kein Autofix – der review-Job blockiert das Gate dann nicht
         # (graceful skip), damit Repos ohne Key mergebar bleiben.
-        if: ${{ secrets.anthropic_api_key != '' }}
+        if: ${{ env.HAS_API_KEY == 'true' }}
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.anthropic_api_key }}


### PR DESCRIPTION
## Problem
`reusable-pr-review.yml@v1` schlägt seit der v1-Tag-Verschiebung am 2026-06-10 in **allen** Repos mit *"This run likely failed because of a workflow file issue"* fehl (0 Jobs, sofortiger `failure`, keine Logs).

## Root Cause
Der autofix-Job hatte ein step-level `if: ${{ secrets.anthropic_api_key != '' }}`. Der `secrets`-Kontext ist in einem step-`if:` **nicht erlaubt** → GitHub lehnt den ganzen Workflow bei der Pre-Flight-Validierung ab. Bestätigt via `actionlint`.

## Fix
- secrets-Wert auf Job-Ebene in `env.HAS_API_KEY` heben (dort zulässig)
- step prüft `if: ${{ env.HAS_API_KEY == 'true' }}`
- Verhalten unverändert (graceful skip ohne API-Key)
- `actionlint` exit 0

## Folge
Entsperrt die blockierten Cleanup-PRs in den anderen Repos. **`v1`-Tag muss nach dem Merge neu auf den Fix-Commit gesetzt werden** — sonst greift der Fix in den Caller-Repos nicht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)