### PR TITLE
fix: id-token: write für autofix (OIDC)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -11,6 +11,7 @@ permissions:
   pull-requests: write
   contents: write
   statuses: write
+  id-token: write   # OIDC-Token für claude-code-action (autofix)
 
 jobs:
   pr-review:

--- a/.github/workflows/reusable-pr-review.yml
+++ b/.github/workflows/reusable-pr-review.yml
@@ -27,6 +27,7 @@ name: Reusable PR Review (Claude)
 #       contents: write        # Autofix-Commits pushen
 #       pull-requests: write    # Review-Kommentare + Labels
 #       statuses: write         # Commit-Status "review-gate"
+#       id-token: write         # OIDC-Token für claude-code-action (autofix)
 #
 # Schleifenschutz / Sicherheit:
 #   - Der Autofix-Push nutzt GITHUB_TOKEN -> löst KEINEN neuen pull_request-Run aus.
@@ -82,6 +83,7 @@ permissions:
   contents: write
   pull-requests: write
   statuses: write
+  id-token: write   # anthropics/claude-code-action@v1 holt einen OIDC-Token (autofix)
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/automation-templates/pr-review.yml
+++ b/automation-templates/pr-review.yml
@@ -11,6 +11,7 @@ permissions:
   pull-requests: write
   contents: write
   statuses: write
+  id-token: write   # OIDC-Token für claude-code-action (autofix)
 
 jobs:
   pr-review:


### PR DESCRIPTION
Folgefix nach dem secrets-Context-Fix (#49/#51): Der autofix-Job startet jetzt, scheitert aber an `Could not fetch an OIDC token. Did you remember to add id-token: write...`. `anthropics/claude-code-action@v1` holt auch mit `anthropic_api_key` einen OIDC-Token.

- `reusable-pr-review.yml`: `id-token: write` in permissions
- `automation-templates/pr-review.yml` + eigener Caller: dito

Caller-Permissions begrenzen den reusable → beide Stellen nötig. `actionlint` exit 0.

**Nach Merge:** v1 neu taggen + `id-token: write` in alle 7 Caller-Repos ausrollen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)