### PR TITLE
fix: id-token: write entfernen (startup_failure)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -11,7 +11,6 @@ permissions:
   pull-requests: write
   contents: write
   statuses: write
-  id-token: write   # OIDC-Token für claude-code-action (autofix)
 
 jobs:
   pr-review:

--- a/.github/workflows/reusable-pr-review.yml
+++ b/.github/workflows/reusable-pr-review.yml
@@ -27,7 +27,6 @@ name: Reusable PR Review (Claude)
 #       contents: write        # Autofix-Commits pushen
 #       pull-requests: write    # Review-Kommentare + Labels
 #       statuses: write         # Commit-Status "review-gate"
-#       id-token: write         # OIDC-Token für claude-code-action (autofix)
 #
 # Schleifenschutz / Sicherheit:
 #   - Der Autofix-Push nutzt GITHUB_TOKEN -> löst KEINEN neuen pull_request-Run aus.
@@ -83,7 +82,6 @@ permissions:
   contents: write
   pull-requests: write
   statuses: write
-  id-token: write   # anthropics/claude-code-action@v1 holt einen OIDC-Token (autofix)
 
 jobs:
   # ---------------------------------------------------------------------------

--- a/automation-templates/pr-review.yml
+++ b/automation-templates/pr-review.yml
@@ -11,7 +11,6 @@ permissions:
   pull-requests: write
   contents: write
   statuses: write
-  id-token: write   # OIDC-Token für claude-code-action (autofix)
 
 jobs:
   pr-review:


### PR DESCRIPTION
Revert des id-token-Fixes (#52). **Befund:** `claude-code-action@v1` läuft mit `contents: write` auch **ohne** `id-token: write` grün (autofix in 6s, verifiziert an safe-my-plants). Sobald der Caller `id-token: write` anfordert, lehnt GitHub den Run mit `startup_failure` ab (Repo-Policy).

→ `id-token: write` überall raus, `contents: write` bleibt (das ist die echte Autofix-Voraussetzung). actionlint exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)