### PR TITLE
PR-Reviews: kostenloses Gate + abo-basierter KI-Review statt metered API

### DIFF
--- a/.github/workflows/mergeability.yml
+++ b/.github/workflows/mergeability.yml
@@ -1,0 +1,19 @@
+name: Mergeability Report
+
+# Kostenloser Mergeability-Report + Merge-Gate (review-gate) bei jedem PR.
+# Keine API-Kosten. Dieses Repo ruft die Reusable lokal auf (gleiches Repo),
+# damit Änderungen am Branch sofort testbar sind. Downstream-Repos nutzen
+# stattdessen das Template automation-templates/mergeability.yml (@v2).
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  mergeability:
+    uses: ./.github/workflows/reusable-mergeability.yml

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,23 +1,24 @@
-name: PR Review (Claude)
+name: PR Review (Claude) — optional, on-demand
 
-# Automatischer Code-Review via Anthropic API bei jedem PR.
-# Voraussetzung: ANTHROPIC_API_KEY als Repository- oder Org-Secret gesetzt.
+# OPTIONALER KI-Review via Anthropic API. ⚠️ Kostet metered API-Token.
+# Läuft NICHT automatisch, sondern nur wenn das Label "ai-review" gesetzt wird.
+# Primärer (kostenloser) Review-Weg: /review aus Claude Code (Pro-Abo).
+# Dieses Repo ruft die Reusable lokal auf (gleiches Repo, sofort testbar).
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [labeled]
 
 permissions:
   pull-requests: write
   contents: read
-  statuses: write
 
 jobs:
   pr-review:
-    uses: S540d/project-templates/.github/workflows/reusable-pr-review.yml@v1
+    if: github.event.label.name == 'ai-review'
+    uses: ./.github/workflows/reusable-pr-review.yml
     secrets:
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
     with:
       language: 'de'
-      # model: 'claude-sonnet-4-6'            # tiefere Analyse (default)
-      # model: 'claude-haiku-4-5-20251001'    # schnell + günstig
+      model: 'claude-haiku-4-5-20251001'   # günstigstes Modell für den Fallback

--- a/.github/workflows/reusable-mergeability.yml
+++ b/.github/workflows/reusable-mergeability.yml
@@ -71,7 +71,11 @@ jobs:
 
           # 2) CI-Checks-Übersicht (check-runs am HEAD; review-gate ist ein Status,
           #    kein check-run, taucht hier also nicht auf).
-          CHECKS_JSON=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" 2>/dev/null || echo '{"check_runs":[]}')
+          # Eigenen Job ("mergeability") herausfiltern – er läuft beim Posten noch
+          # und würde sonst dauerhaft als ⏳ erscheinen.
+          CHECKS_JSON=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" 2>/dev/null \
+            | jq '{check_runs: [.check_runs[] | select(.name != "mergeability")]}' \
+            2>/dev/null || echo '{"check_runs":[]}')
           CHECK_LINES=$(printf '%s' "$CHECKS_JSON" | jq -r '
             .check_runs
             | if length == 0 then "_keine CI-Checks gefunden_"

--- a/.github/workflows/reusable-mergeability.yml
+++ b/.github/workflows/reusable-mergeability.yml
@@ -1,0 +1,158 @@
+name: Reusable Mergeability Report
+
+# Kostenloser, deterministischer Mergeability-Report + Merge-Gate – OHNE API-Kosten.
+# Aufruf versioniert (@v2):
+#
+#   jobs:
+#     mergeability:
+#       uses: S540d/project-templates/.github/workflows/reusable-mergeability.yml@v2
+#
+# Pro PR:
+#   - postet/aktualisiert einen Sticky-Kommentar (Zielbranch, Konflikt-Status,
+#     CI-Übersicht, Checkliste)
+#   - setzt den Commit-Status "review-gate":
+#       kein Merge-Konflikt      -> success
+#       Merge-Konflikt           -> failure
+#       (optional) falscher Base -> failure, nur wenn block_on_protected_base=true
+#
+# Reine GitHub-API via `gh` — verbraucht KEINE Anthropic-API-Token. Übernimmt die
+# Gate-Rolle, die früher in reusable-pr-review.yml lag. Der Status-Context heißt
+# weiterhin "review-gate", damit bestehende Branch-Protection-Rulesets greifen.
+#
+# Voraussetzungen im Caller:
+#   - Trigger: pull_request (opened, synchronize, reopened)
+#   - permissions: contents: read, pull-requests: write, statuses: write
+
+on:
+  workflow_call:
+    inputs:
+      protected_branch:
+        description: 'Branch, gegen den direkte Feature-PRs als Policy-Verstoß markiert werden'
+        required: false
+        type: string
+        default: 'main'
+      block_on_protected_base:
+        description: 'Wenn true, blockiert das Gate auch direkte PRs gegen protected_branch'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  mergeability:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report mergeability and set review-gate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          PROTECTED_BRANCH: ${{ inputs.protected_branch }}
+          BLOCK_ON_BASE: ${{ inputs.block_on_protected_base }}
+        run: |
+          set -euo pipefail
+          REPO="$GITHUB_REPOSITORY"
+
+          # 1) Mergeable-Status holen. GitHub berechnet das asynchron -> kurz pollen.
+          MERGEABLE="null"; MERGE_STATE="unknown"
+          for _ in 1 2 3 4 5; do
+            PR_JSON=$(gh api "repos/$REPO/pulls/$PR_NUMBER")
+            MERGEABLE=$(printf '%s' "$PR_JSON" | jq -r '.mergeable')
+            MERGE_STATE=$(printf '%s' "$PR_JSON" | jq -r '.mergeable_state')
+            [ "$MERGEABLE" != "null" ] && break
+            sleep 3
+          done
+
+          # 2) CI-Checks-Übersicht (check-runs am HEAD; review-gate ist ein Status,
+          #    kein check-run, taucht hier also nicht auf).
+          CHECKS_JSON=$(gh api "repos/$REPO/commits/$HEAD_SHA/check-runs" 2>/dev/null || echo '{"check_runs":[]}')
+          CHECK_LINES=$(printf '%s' "$CHECKS_JSON" | jq -r '
+            .check_runs
+            | if length == 0 then "_keine CI-Checks gefunden_"
+              else map(
+                (if .status != "completed" then "⏳ "
+                 elif .conclusion == "success" then "✅ "
+                 elif .conclusion == "skipped" then "⏭️ "
+                 else "❌ " end) + .name
+              ) | join("\n")
+              end')
+          CI_FAILED=$(printf '%s' "$CHECKS_JSON" | jq -r '
+            [.check_runs[] | select(.status=="completed" and (.conclusion|IN("failure","timed_out","cancelled","action_required")))] | length')
+
+          # 3) Konflikt- und Zielbranch-Auswertung.
+          if [ "$MERGEABLE" = "false" ]; then
+            CONFLICT_LINE="❌ **Merge-Konflikt** – aktuell nicht konfliktfrei mergebar (\`$MERGE_STATE\`)."
+            HAS_CONFLICT=1
+          elif [ "$MERGEABLE" = "true" ]; then
+            CONFLICT_LINE="✅ Konfliktfrei mergebar (\`$MERGE_STATE\`)."
+            HAS_CONFLICT=0
+          else
+            CONFLICT_LINE="⏳ Mergeability wird von GitHub noch berechnet – wird beim nächsten Push erneut geprüft."
+            HAS_CONFLICT=0
+          fi
+
+          BASE_VIOLATION=0
+          if [ "$BASE_REF" = "$PROTECTED_BRANCH" ]; then
+            BASE_LINE="⚠️ Ziel-Branch \`$BASE_REF\` – laut Policy gehen Feature-PRs gegen \`testing\`, nicht direkt gegen \`$PROTECTED_BRANCH\`."
+            BASE_VIOLATION=1
+          else
+            BASE_LINE="✅ Ziel-Branch \`$BASE_REF\` ist policy-konform."
+          fi
+
+          # 4) Gate: Konflikt blockt immer; falscher Base nur wenn aktiviert.
+          GATE="success"; GATE_DESC="Konfliktfrei – Merge möglich"
+          if [ "$HAS_CONFLICT" = "1" ]; then
+            GATE="failure"; GATE_DESC="Merge-Konflikt – bitte Branch aktualisieren"
+          elif [ "$BLOCK_ON_BASE" = "true" ] && [ "$BASE_VIOLATION" = "1" ]; then
+            GATE="failure"; GATE_DESC="Ziel-Branch '$BASE_REF' nicht policy-konform"
+          fi
+
+          gh api "repos/$REPO/statuses/$HEAD_SHA" \
+            --method POST \
+            -f state="$GATE" \
+            -f context="review-gate" \
+            -f description="$GATE_DESC"
+
+          # 5) Sticky-Kommentar bauen.
+          if [ "$CI_FAILED" -gt 0 ]; then
+            CI_SUMMARY="❌ $CI_FAILED fehlgeschlagene(r) Check(s)"
+          else
+            CI_SUMMARY="✅ keine fehlgeschlagenen Checks"
+          fi
+          MARKER="<!-- mergeability-report -->"
+          BODY="$MARKER
+          ## 🔀 Mergeability-Report
+
+          $CONFLICT_LINE
+          $BASE_LINE
+
+          **CI-Checks:** $CI_SUMMARY
+
+          $CHECK_LINES
+
+          ### Merge-Checkliste
+          - CI-Checks grün
+          - Keine Merge-Konflikte
+          - Ziel-Branch korrekt
+          - (Optional) tiefes KI-Review via \`/review\` aus Claude Code (Pro-Abo, ohne API-Kosten)
+
+          ---
+          *Kostenlos generiert von [reusable-mergeability.yml](https://github.com/S540d/project-templates/blob/main/.github/workflows/reusable-mergeability.yml) · keine API-Kosten · review-gate: \`$GATE\`*"
+
+          # 6) Bestehenden Report-Kommentar finden -> aktualisieren, sonst neu anlegen.
+          EXISTING_ID=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
+            | jq -r --arg m "$MARKER" 'map(select(.body | startswith($m))) | (.[0].id // empty)')
+
+          if [ -n "$EXISTING_ID" ]; then
+            gh api "repos/$REPO/issues/comments/$EXISTING_ID" --method PATCH -f body="$BODY" >/dev/null
+            echo "Sticky-Kommentar $EXISTING_ID aktualisiert (review-gate=$GATE)."
+          else
+            gh api "repos/$REPO/issues/$PR_NUMBER/comments" --method POST -f body="$BODY" >/dev/null
+            echo "Sticky-Kommentar neu angelegt (review-gate=$GATE)."
+          fi

--- a/.github/workflows/reusable-pr-review.yml
+++ b/.github/workflows/reusable-pr-review.yml
@@ -1,32 +1,38 @@
 name: Reusable PR Review (Claude)
 
-# Deterministischer PR-Review via Anthropic API. Aufruf versioniert (@v1):
+# OPTIONALER, BERATENDER KI-Review via Anthropic API. ⚠️ Kostet metered API-Token.
+# Läuft NICHT automatisch — der Caller triggert ihn on-demand (Label "ai-review").
+# Aufruf versioniert (@v2):
 #
 #   jobs:
 #     pr-review:
-#       uses: S540d/project-templates/.github/workflows/reusable-pr-review.yml@v1
+#       uses: S540d/project-templates/.github/workflows/reusable-pr-review.yml@v2
 #       secrets:
 #         anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 #       with:
 #         language: 'de'
+#         model: 'claude-haiku-4-5-20251001'
 #
 # Ablauf (ein Job):
-#   review – Claude reviewt den PR-Diff, postet einen Review-Kommentar
-#            (+ Inline-Findings), setzt den Commit-Status "review-gate"
-#            und vergibt das Status-Label:
-#              - keine Findings  -> "ready to merge"     (Mensch merged manuell)
-#              - Findings übrig  -> "needs human review" (menschliche Entscheidung)
+#   review – Claude reviewt den PR-Diff und postet einen Review-Kommentar
+#            (+ Inline-Findings). REIN BERATEND: setzt KEINEN Status und KEINE
+#            Labels und blockiert den Merge nicht.
+#
+# Das Merge-Gate ("review-gate") wird stattdessen kostenlos von
+# reusable-mergeability.yml gesetzt (Konflikt-/Zielbranch-Check, keine API-Kosten).
+#
+# Primärer (kostenloser) Review-Weg: /review aus Claude Code (Pro-Abo) — lokal am
+# PC oder in einer Web-Session vom Telefon, ohne Pay-per-Token. Dieser Workflow
+# ist nur der optionale API-Fallback.
 #
 # Voraussetzungen:
 #   - Secret ANTHROPIC_API_KEY (Repo oder Org)
-#   - Trigger im Caller: pull_request (opened, synchronize, reopened)
+#   - Trigger im Caller: pull_request [labeled], if label.name == 'ai-review'
 #   - permissions im Caller:
 #       contents: read          # PR-Branch auschecken
-#       pull-requests: write    # Review-Kommentare + Labels
-#       statuses: write         # Commit-Status "review-gate"
+#       pull-requests: write    # Review-Kommentare
 #
-# Repos ohne ANTHROPIC_API_KEY: Review wird übersprungen, Gate bleibt offen
-# (mergebar). So bleiben Repos ohne Key nicht dauerhaft blockiert.
+# Repos ohne ANTHROPIC_API_KEY: Review wird übersprungen (kein Gate-Effekt).
 
 on:
   workflow_call:
@@ -46,16 +52,6 @@ on:
         required: false
         type: number
         default: 40000
-      ready_label:
-        description: 'Label, das gesetzt wird, wenn der Review sauber ist'
-        required: false
-        type: string
-        default: 'ready to merge'
-      attention_label:
-        description: 'Label, das gesetzt wird, wenn Findings menschliche Entscheidung brauchen'
-        required: false
-        type: string
-        default: 'needs human review'
     secrets:
       anthropic_api_key:
         description: 'Anthropic API Key'
@@ -64,11 +60,10 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  statuses: write
 
 jobs:
   # ---------------------------------------------------------------------------
-  # Deterministischer Review des PR-Stands + Gate + Label.
+  # Beratender Review des PR-Stands (Kommentar + Inline-Findings, KEIN Gate/Label).
   # ---------------------------------------------------------------------------
   review:
     if: ${{ github.event_name == 'pull_request' }}
@@ -264,25 +259,16 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REVIEW_TEXT: ${{ steps.review.outputs.review_text }}
           DIFF_CHARS: ${{ steps.diff.outputs.char_count }}
-          FINDINGS: ${{ steps.review.outputs.findings }}
           MODEL: ${{ inputs.model }}
-          READY_LABEL: ${{ inputs.ready_label }}
-          ATTENTION_LABEL: ${{ inputs.attention_label }}
         run: |
-          if [ "$FINDINGS" = "yes" ]; then
-            GATE_LINE="🔴 **Merge-Gate aktiv:** Es sind Findings offen, die eine menschliche Entscheidung brauchen. Label **\`$ATTENTION_LABEL\`** gesetzt — bitte prüfen."
-          else
-            GATE_LINE="🟢 **Merge-Gate:** keine offenen Findings — Label **\`$READY_LABEL\`** gesetzt, Merge kann manuell erfolgen."
-          fi
-
-          COMMENT_BODY="## 🤖 Claude Code Review
+          COMMENT_BODY="## 🤖 Claude Code Review (beratend)
 
           $REVIEW_TEXT
 
-          $GATE_LINE
+          ℹ️ *Dieser KI-Review ist rein beratend und blockiert den Merge nicht. Das Merge-Gate (\`review-gate\`) wird kostenlos vom Mergeability-Workflow gesetzt.*
 
           ---
-          *Automatisch generiert von [reusable-pr-review.yml](https://github.com/S540d/project-templates/blob/main/.github/workflows/reusable-pr-review.yml) · Modell: \`$MODEL\` · Diff: ${DIFF_CHARS} Zeichen*"
+          *On-demand erzeugt von [reusable-pr-review.yml](https://github.com/S540d/project-templates/blob/main/.github/workflows/reusable-pr-review.yml) · Modell: \`$MODEL\` · Diff: ${DIFF_CHARS} Zeichen · ⚠️ metered API*"
 
           gh pr comment "$PR_NUMBER" \
             --repo "$GITHUB_REPOSITORY" \
@@ -327,46 +313,7 @@ jobs:
           PAYLOAD=$(jq -n --arg sha "$HEAD_SHA" --argjson comments "$COMMENTS" \
             '{ commit_id: $sha, event: "COMMENT", body: "Claude: Inline-Findings (siehe Kommentare).", comments: $comments }')
 
-          # Best effort: ungültige Positionen ignorieren, Gate hängt nicht davon ab.
+          # Best effort: ungültige Positionen ignorieren — der Review ist beratend.
           gh api "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" \
             --method POST --input - <<< "$PAYLOAD" || \
             echo "::warning::Inline-Kommentare konnten nicht (alle) gesetzt werden — Findings stehen im Sammelkommentar."
-
-      - name: Set review-gate status and merge label
-        if: always()
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          HEAD_SHA: ${{ steps.sha.outputs.head }}
-          FINDINGS: ${{ steps.review.outputs.findings }}
-          SKIPPED: ${{ steps.review.outputs.skipped }}
-          READY_LABEL: ${{ inputs.ready_label }}
-          ATTENTION_LABEL: ${{ inputs.attention_label }}
-        run: |
-          # Default failure: wenn der findings-Output fehlt (z.B. Step abgebrochen) -> sicher blocken.
-          STATE="failure"
-          DESC="Findings offen — '$ATTENTION_LABEL' gesetzt"
-          if [ "$FINDINGS" = "no" ]; then
-            STATE="success"
-            DESC="Keine offenen Findings — '$READY_LABEL' gesetzt"
-          fi
-
-          gh api "repos/$GITHUB_REPOSITORY/statuses/$HEAD_SHA" \
-            --method POST \
-            -f state="$STATE" \
-            -f context="review-gate" \
-            -f description="$DESC"
-
-          # Labels nur setzen, wenn tatsächlich reviewt wurde (kein graceful skip).
-          if [ "$SKIPPED" = "true" ]; then
-            echo "Review übersprungen — keine Merge-Labels gesetzt, Gate offen."
-            exit 0
-          fi
-
-          if [ "$STATE" = "success" ]; then
-            gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
-              --add-label "$READY_LABEL" --remove-label "$ATTENTION_LABEL" 2>/dev/null || true
-          else
-            gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
-              --add-label "$ATTENTION_LABEL" --remove-label "$READY_LABEL" 2>/dev/null || true
-          fi

--- a/README.md
+++ b/README.md
@@ -35,20 +35,24 @@ Zentrale Vorlagen und Standards für alle Projekte von [DevSven](https://github.
 
 ## Reusable Workflows
 
-Immer mit festem Tag aufrufen (`@v1`, nie `@main`):
+Immer mit festem Tag aufrufen (`@v2`, nie `@main`):
 
 ```yaml
-uses: S540d/project-templates/.github/workflows/reusable-pr-review.yml@v1
+uses: S540d/project-templates/.github/workflows/reusable-mergeability.yml@v2
 ```
 
 | Workflow | Verhalten |
 |---|---|
-| `reusable-pr-review.yml` | Claude-PR-Review + autonomer Autofix; setzt `ready to merge` / `needs human review`; graceful skip wenn `ANTHROPIC_API_KEY` fehlt |
+| `reusable-mergeability.yml` | **Kostenloses** Merge-Gate: Sticky-Report (Konflikt/Zielbranch/CI) + setzt `review-gate`. Keine API-Kosten |
+| `reusable-pr-review.yml` | **Optionaler** KI-Review (Anthropic API, ⚠️ metered); on-demand via Label `ai-review`; rein beratend, kein Gate |
 | `reusable-security-scan.yml` | fail-closed (Funde + Scanner-Fehler brechen ab) |
 | `reusable-ci-quality.yml` | lint / type-check / test – konfigurierbar |
 | `reusable-gitignore-audit.yml` | blocking; Pflicht-Ignores + keine getrackten Secrets |
 | `reusable-dev-standards-audit.yml` | non-blocking Hinweis-Audit |
 | `weekly-audit.yml` | Cron Mo 08:00 – braucht `ORG_AUTOMATION_TOKEN` |
+
+> Tiefer KI-Review ohne API-Kosten: `/review` aus Claude Code (Pro/Max-Abo) — lokal
+> oder als Web-Session. Die metered `reusable-pr-review.yml` ist nur der Fallback.
 
 ---
 

--- a/automation-templates/AUTOMATION_SETUP.md
+++ b/automation-templates/AUTOMATION_SETUP.md
@@ -266,44 +266,46 @@ git push origin v1.0.9
 
 ---
 
-## 🤖 Claude PR-Review mit autonomer Korrektur
+## 🔀 PR-Review & Merge-Gate (kostenlos + abo-basiert)
 
-Jeder PR durchläuft automatisch zwei Schritte (ein Workflow-Run, `reusable-pr-review.yml`):
+Statt bei jedem PR die (metered) Anthropic-API zu rufen, gilt ein Drei-Schichten-Modell:
 
-1. **Autofix** — Ein Claude-Agent (`anthropics/claude-code-action`) reviewt den PR,
-   **korrigiert alle umsetzbaren Findings selbst**, committet (`[auto]`) und pusht auf
-   den PR-Branch. Er iteriert intern, bis nichts Umsetzbares mehr offen ist.
-2. **Review** — Ein deterministischer Review des **korrigierten End-Stands** postet den
-   Review-Kommentar, setzt den required Status-Check **`review-gate`** und vergibt das
-   Status-Label.
+### 1. Kostenloses Gate — `mergeability.yml` (automatisch, keine API-Kosten)
 
-### Funktionsweise
+Läuft bei jedem PR (`reusable-mergeability.yml@v2`), postet einen **Sticky-Kommentar**
+(Zielbranch, Konflikt-Status, CI-Übersicht, Checkliste) und setzt den required
+Status-Check **`review-gate`** via reiner GitHub-API:
 
-| Situation | `review-gate` | Label | Merge |
-|---|---|---|---|
-| Alles auto-korrigiert / nichts zu tun | 🟢 grün | `ready to merge` | manuell durch dich |
-| Findings brauchen menschliche Entscheidung | 🔴 rot | `needs human review` | erst nach Klärung |
-| API-Ausfall / kein Findings-Marker | 🔴 rot | — | gesperrt (fail-closed) |
+| Situation | `review-gate` | Merge |
+|---|---|---|
+| Konfliktfrei | 🟢 grün | möglich (sofern CI grün) |
+| Merge-Konflikt | 🔴 rot | erst Branch aktualisieren |
+| (optional) PR direkt gegen `main` | 🔴 rot* | nur bei `block_on_protected_base: true` |
 
-- **Du merged manuell**, sobald `ready to merge` gesetzt ist. Es gibt **kein** manuelles
-  Quittierungs-Label mehr — der Agent erledigt die Korrektur selbst.
-- **Re-Review:** Jeder neue (menschliche) Push startet einen frischen Lauf. Der Autofix-Push
-  selbst nutzt `GITHUB_TOKEN` und löst **keinen** neuen Lauf aus (Schleifenschutz).
-- **Forks:** Kein Autofix (Secrets/Schreibrechte fehlen); der Review läuft read-only.
-- **Sicherheit:** Bei API-Ausfall / fehlendem Findings-Marker bleibt der Check **rot**.
+### 2. Tiefer KI-Review — `/review` aus Claude Code (primär, ohne Pay-per-Token)
+
+Führe `/review` bzw. `/code-review --comment` aus Claude Code aus — **lokal am PC
+oder in einer Web-Session vom Telefon**. Gedeckt durch dein Pro/Max-Abo, **keine
+metered API-Kosten**. `--comment` postet Findings an den PR, `--fix` setzt sie um.
+
+### 3. Optionaler API-Fallback — Label `ai-review` (⚠️ metered)
+
+Setzt du das Label **`ai-review`** an einen PR, läuft `pr-review.yml`
+(`reusable-pr-review.yml@v2`, Haiku) und postet einen **beratenden** Review. Er
+blockiert den Merge **nicht**. Verbraucht Anthropic-API-Token — nur bewusst nutzen.
 
 ### Einrichtung pro Repo
 
-1. Secret `ANTHROPIC_API_KEY` (Repo oder Org).
-2. Workflow `.github/workflows/pr-review.yml` (ruft `reusable-pr-review.yml@v1`,
-   braucht `permissions: pull-requests: write, contents: read, statuses: write`).
-3. Labels `ready to merge` + `needs human review` anlegen (via `scripts/setup-labels.sh`).
-4. `review-gate` als required status check ins `protect-main`-Ruleset (siehe
-   `github-ruleset-protect-main-*.json`).
+1. Workflow `.github/workflows/mergeability.yml` (kostenloses Gate, keine Secrets).
+2. Labels via `scripts/setup-labels.sh` (`ready to merge`, `needs human review`, `ai-review`).
+3. `review-gate` als required status check im `protect-main`-Ruleset (der Context-Name
+   bleibt `review-gate` — bestehende Rulesets greifen unverändert).
+4. **Optional** für den API-Fallback: Secret `ANTHROPIC_API_KEY` + Workflow
+   `.github/workflows/pr-review.yml`. Ohne Key entfällt nur der Fallback; Gate &
+   `/review` funktionieren weiter.
 
-> ⚠️ Den Ruleset-Check `review-gate` **erst** aktivieren, wenn die Workflows im Repo liegen
-> und der Check einmal gelaufen ist — sonst wartet GitHub auf einen nie laufenden Check und
-> blockiert jeden PR.
+> ⚠️ Den Ruleset-Check `review-gate` **erst** aktivieren, wenn `mergeability.yml` im Repo
+> liegt und einmal gelaufen ist — sonst wartet GitHub auf einen nie laufenden Check.
 
 ---
 

--- a/automation-templates/mergeability.yml
+++ b/automation-templates/mergeability.yml
@@ -1,0 +1,21 @@
+name: Mergeability Report
+
+# Kostenloser Mergeability-Report + Merge-Gate (review-gate) bei jedem PR.
+# Postet einen Sticky-Kommentar (Zielbranch, Konflikt-Status, CI-Übersicht,
+# Checkliste) und setzt den required Status-Check "review-gate". Reine GitHub-API,
+# verbraucht KEINE Anthropic-API-Token. Keine Secrets nötig.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: read
+  pull-requests: write
+  statuses: write
+
+jobs:
+  mergeability:
+    uses: S540d/project-templates/.github/workflows/reusable-mergeability.yml@v2
+    # with:
+    #   block_on_protected_base: true   # zusätzlich direkte PRs gegen main blocken

--- a/automation-templates/pr-review.yml
+++ b/automation-templates/pr-review.yml
@@ -1,23 +1,30 @@
-name: PR Review (Claude)
+name: PR Review (Claude) — optional, on-demand
 
-# Automatischer Code-Review via Anthropic API bei jedem PR.
-# Voraussetzung: ANTHROPIC_API_KEY als Repository- oder Org-Secret gesetzt.
+# OPTIONALER KI-Review via Anthropic API. ⚠️ Kostet metered API-Token.
+# Läuft NICHT automatisch, sondern nur wenn das Label "ai-review" an den PR
+# vergeben wird. Rein beratend — blockiert den Merge nicht (das Gate setzt der
+# kostenlose mergeability.yml-Workflow).
+#
+# Primärer, kostenloser Review-Weg: /review aus Claude Code (Pro/Max-Abo) — lokal
+# am PC oder in einer Web-Session vom Telefon, ohne Pay-per-Token. Dieser Workflow
+# ist nur der optionale API-Fallback.
+#
+# Voraussetzung: Secret ANTHROPIC_API_KEY (Repo oder Org) + Label "ai-review".
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [labeled]
 
 permissions:
   pull-requests: write
   contents: read
-  statuses: write
 
 jobs:
   pr-review:
-    uses: S540d/project-templates/.github/workflows/reusable-pr-review.yml@v1
+    if: github.event.label.name == 'ai-review'
+    uses: S540d/project-templates/.github/workflows/reusable-pr-review.yml@v2
     secrets:
       anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
     with:
       language: 'de'
-      # model: 'claude-sonnet-4-6'            # tiefere Analyse (default)
-      # model: 'claude-haiku-4-5-20251001'    # schnell + günstig
+      model: 'claude-haiku-4-5-20251001'   # günstigstes Modell für den Fallback

--- a/claude-commands/pr-review.md
+++ b/claude-commands/pr-review.md
@@ -52,21 +52,27 @@ Einen Pull Request gründlich prüfen, Code-Review-Suggestions umsetzen und für
 - Falls neue Features/Breaking Changes: Schlage CHANGELOG-Eintrag vor
 - Prüfe ob README/Docs aktualisiert werden müssen
 
-### 6. Merge-Gate (review-gate) – automatischer Claude-Review + Autofix
+### 6. Merge-Gate (review-gate) + KI-Review
 
-Der Workflow `reusable-pr-review.yml` korrigiert den PR automatisch und reviewt
-den End-Stand, dann setzt er den required Status-Check **`review-gate`** und ein Label:
+**Kostenloses Gate (automatisch, keine API-Kosten):** Der Workflow
+`reusable-mergeability.yml` läuft bei jedem PR, postet einen Sticky-Kommentar
+(Zielbranch, Konflikt-Status, CI-Übersicht, Checkliste) und setzt den required
+Status-Check **`review-gate`**:
+- **kein Merge-Konflikt → grün** → Merge möglich (sofern auch CI grün ist).
+- **Merge-Konflikt → rot** → Branch aktualisieren.
 
-1. **Autofix:** Ein Claude-Agent fixt alle umsetzbaren Findings selbst (Commit `[auto]` + Push).
-2. **Review:** bewertet den korrigierten Stand:
-   - **Keine offenen Findings → grün** + Label `ready to merge` → Merge frei.
-   - **Findings übrig → rot** + Inline-Kommentare + Label `needs human review`.
+**Tiefer KI-Review (primärer Weg, abo-basiert, ohne Pay-per-Token):** Führe das
+Slash-Command `/review` (bzw. `/code-review --comment`) aus Claude Code aus —
+lokal am PC **oder** in einer Web-Session vom Telefon. Das ist durch dein
+Pro/Max-Abo gedeckt und kostet keine metered API-Token. Mit `--comment` werden die
+Findings als PR-Kommentare gepostet, mit `--fix` direkt im Working-Tree umgesetzt.
 
-Bei `needs human review`: Findings lesen, klären/umsetzen, pushen → frischer Lauf.
+**Optionaler API-Fallback (kostet metered API):** Setze das Label **`ai-review`**
+am PR → `pr-review.yml` postet einen beratenden Claude-Review (Haiku). Dieser
+blockiert den Merge **nicht** — er ergänzt nur das kostenlose Gate.
 
-> ⚠️ Es gibt **kein** manuelles Quittierungs-Label mehr. Den roten Gate öffnet nur
-> ein sauberer Review (alle Findings gelöst). Solange `needs human review` gesetzt
-> ist: **nicht mergen**, bis die offenen Punkte geklärt sind.
+> ℹ️ Der KI-Review ist beratend; verbindlich für den Merge sind die kostenlosen,
+> deterministischen Checks (CI grün + `review-gate` grün + keine Konflikte).
 
 ### 7. Merge vorbereiten
 - Prüfe ob alle Checks grün sind (inkl. `review-gate`)
@@ -129,7 +135,7 @@ Bei `needs human review`: Findings lesen, klären/umsetzen, pushen → frischer 
 **KRITISCH - NIEMALS automatisch mergen wenn:**
 - ❌ CI/CD Tests fehlgeschlagen
 - ❌ Merge Conflicts vorhanden
-- ❌ `review-gate` ist rot bzw. Label `needs human review` gesetzt (offene Findings erst klären)
+- ❌ `review-gate` ist rot (Merge-Konflikt – erst Branch aktualisieren)
 - ❌ Target-Branch ist `main` oder `production` (extra Vorsicht, nur mit Freigabe + `--admin`)
 
 **Immer fragen vor:**

--- a/dev-standards/global-policy.md
+++ b/dev-standards/global-policy.md
@@ -56,15 +56,21 @@ Jedes Repo muss in `.gitignore` enthalten:
 - `CLAUDE.md` im Root wird von Claude Code automatisch gelesen und ist für alle Entwickler sichtbar
 - `.claude/` enthält lokale Commands und Settings, die gerätespezifisch sind und nicht ins Repo gehören
 
-## Automatischer PR-Review mit autonomer Korrektur
-Alle Repos haben `pr-review.yml` (`reusable-pr-review.yml@v1`). Pro PR läuft:
-1. **Autofix:** Claude-Agent korrigiert alle umsetzbaren Findings selbst (Commit `[auto]` + Push).
-2. **Review:** bewertet den End-Stand, setzt `review-gate` und das Label
-   `ready to merge` (sauber) bzw. `needs human review` (menschliche Entscheidung nötig).
+## PR-Review & Merge-Gate (kostenlos + abo-basiert)
+Die früher metered, pro PR laufende Anthropic-API ist abgelöst. Neues Modell:
 
-Du merged manuell, sobald `ready to merge` gesetzt ist (kein Quittierungs-Label mehr).
-Voraussetzung: `ANTHROPIC_API_KEY` als Repository-Secret und
-`permissions: contents: write, pull-requests: write, statuses: write`.
+1. **Kostenloses Gate (automatisch):** `mergeability.yml`
+   (`reusable-mergeability.yml@v2`) läuft bei jedem PR, postet einen
+   Sticky-Mergeability-Kommentar und setzt `review-gate`
+   (grün ohne Konflikt, rot bei Konflikt). Reine GitHub-API, keine API-Kosten.
+   CI-Quality + Security-Scan bleiben eigene required Checks.
+2. **Tiefer KI-Review (primär, abo-basiert):** `/review` aus Claude Code (Pro/Max)
+   — lokal am PC oder per Web-Session vom Telefon, ohne Pay-per-Token.
+3. **Optionaler API-Fallback:** Label `ai-review` triggert `pr-review.yml`
+   (`reusable-pr-review.yml@v2`, Haiku) — rein beratend, ⚠️ metered.
+
+Du merged manuell, sobald CI grün und `review-gate` grün sind.
+`ANTHROPIC_API_KEY` ist nur noch für den optionalen Fallback nötig (kein Pflicht-Secret).
 
 ## Branch Protection (Rulesets)
 `main` und `testing` sind in allen Repos per Ruleset geschützt:

--- a/docs/github/LABELS.md
+++ b/docs/github/LABELS.md
@@ -7,7 +7,7 @@ Einfaches, einheitliches Label-System für alle Projekte.
 
 ## Übersicht
 
-Insgesamt **11 Labels** in 4 Kategorien (inkl. 2 automatisch gesetzte PR-Review-Gate-Labels):
+Insgesamt **12 Labels** in 4 Kategorien (inkl. PR-Review-/Gate-Labels):
 
 ### Type Labels (Was ist das Issue?)
 
@@ -32,15 +32,17 @@ Insgesamt **11 Labels** in 4 Kategorien (inkl. 2 automatisch gesetzte PR-Review-
 | `blocked` | ⚫ #3d3d3d | Blockiert - wartet auf etwas |
 | `ready-for-implementation` | ✅ #34b13e | Ready - kann angefangen werden |
 
-### PR-Review-Gate Labels (automatisch gesetzt)
+### PR-Review-/Gate Labels
 
-Diese Labels werden vom Claude-PR-Review-Workflow (`reusable-pr-review.yml`)
-**automatisch** an Pull Requests vergeben — nicht manuell setzen.
+`ready to merge` / `needs human review` markieren den Review-Stand (manuell oder
+durch Tooling). `ai-review` ist ein **Trigger**: an einen PR vergeben, stößt es den
+optionalen, metered KI-Review (`pr-review.yml`) an.
 
 | Label | Farbe | Beschreibung |
 |-------|-------|-------------|
 | `ready to merge` | 🟢 #0e8a16 | Review sauber/aufgelöst — Merge kann manuell erfolgen |
 | `needs human review` | 🔴 #d93f0b | Findings brauchen menschliche Entscheidung — bitte prüfen |
+| `ai-review` | 🟣 #5319e7 | Optionalen KI-Review (Anthropic API) anstoßen — ⚠️ kostet metered API |
 
 ---
 

--- a/docs/github/MIGRATION-v2.md
+++ b/docs/github/MIGRATION-v2.md
@@ -1,0 +1,38 @@
+# Migration auf v2 – kostenloses Merge-Gate + abo-basierter KI-Review
+
+Ablösung des metered API-Reviews (lief pro PR-Push) durch ein Drei-Schichten-Modell.
+Tracking: Issue #62.
+
+## Was sich ändert
+| | vorher (v1) | nachher (v2) |
+|---|---|---|
+| Gate | Claude-API setzt `review-gate` (metered, jeder Push) | `mergeability.yml` setzt `review-gate` (kostenlos, GitHub-API) |
+| Tiefer Review | automatisch via API | `/review` aus Claude Code (Pro/Max-Abo, ohne Pay-per-Token) |
+| API-Review | immer | optional, on-demand via Label `ai-review` (Haiku, beratend) |
+| `ANTHROPIC_API_KEY` | Pflicht | nur für optionalen Fallback |
+
+Der Status-Context bleibt **`review-gate`** → bestehende Rulesets greifen unverändert.
+
+## Pro Repo migrieren
+
+Schnellweg mit dem Kit (aus dem project-templates-Klon):
+
+```bash
+./scripts/migrate-to-v2.sh S540d/<RepoName> /abs/pfad/zum/<RepoName>-klon
+# danach im Klon: Branch + Commit + PR gegen testing (siehe Skript-Ausgabe)
+```
+
+Das Kit kopiert `mergeability.yml` + `pr-review.yml` in `.github/workflows/`,
+setzt die Labels (inkl. `ai-review`) und druckt die nächsten Git-Schritte.
+
+## Reihenfolge (Rollout)
+1. **Pilot:** `safe-my-plants` – 2–3 echte PRs beobachten.
+2. **Kern-Batch:** `1x1_Trainer` → `DrawFromMemory` → `Pflanzkalender` → `Epic_Calendar` → `Eisenhauer`.
+3. Danach `@v1` als deprecated markieren.
+
+## Verifikation pro Repo
+- [ ] Mergeability-Sticky-Kommentar erscheint am PR und aktualisiert sich bei Push
+- [ ] `review-gate` grün bei konfliktfreiem PR, rot bei Konflikt
+- [ ] kein automatischer API-Call (kein `pr-review`-Lauf ohne Label `ai-review`)
+- [ ] Label `ai-review` triggert beratenden Review, ohne das Gate zu verändern
+- [ ] `/review` aus Claude Code postet Findings (Abo, ohne API-Kosten)

--- a/docs/github/ROLLOUT-EXECUTION.md
+++ b/docs/github/ROLLOUT-EXECUTION.md
@@ -1,0 +1,88 @@
+# Ausführungs-Anleitung: Rollout v2 (am PC ausführen)
+
+Schritt-für-Schritt zum Abschluss der Umstellung auf das v2-Review-Modell
+(kostenloses Merge-Gate + abo-basierter KI-Review). Hintergrund & Status: Issue #62.
+
+> Diese Schritte brauchen Schreibzugriff (gh-Login als Repo-Admin) und gehen daher
+> **nicht** aus einer Sandbox-Session, sondern lokal am PC.
+
+## Voraussetzungen
+```bash
+gh auth status                       # eingeloggt als S540d (Admin)
+git clone https://github.com/S540d/project-templates   # falls noch kein Klon
+cd project-templates
+```
+
+## Schritt 1 — PR #61 mergen
+`main` ist per Ruleset geschützt (0 Approvals, aber PR-Pflicht) → Solo-Merge via `--admin`.
+```bash
+gh pr merge 61 --repo S540d/project-templates --squash --admin
+```
+Erwartung: PR #61 ist „Merged", `main` enthält die 3 Commits (Mergeability-Workflow,
+Self-Filter-Fix, Migrations-Kit).
+
+## Schritt 2 — Tag `v2` setzen
+`v1` bleibt unverändert (zeigt auf den alten Stand → Downstream-`@v1` friert ein).
+Neuer Tag `v2` für die umgestellten Reusables:
+```bash
+git fetch origin main
+git tag -a v2 origin/main -m "v2: kostenloses Merge-Gate (mergeability) + on-demand KI-Review"
+git push origin v2
+```
+Prüfen: `git ls-remote --tags origin v2` zeigt den Tag.
+
+## Schritt 3 — Pilot: safe-my-plants
+Aus dem **project-templates-Klon** (enthält das Kit `scripts/migrate-to-v2.sh`):
+```bash
+# lokalen Klon des Ziel-Repos bereitstellen
+git clone https://github.com/S540d/safe-my-plants ~/code/safe-my-plants
+
+# Workflows + Labels einspielen (dry-run zum Anschauen, dann echt)
+./scripts/migrate-to-v2.sh --dry-run S540d/safe-my-plants ~/code/safe-my-plants
+./scripts/migrate-to-v2.sh         S540d/safe-my-plants ~/code/safe-my-plants
+
+# im Ziel-Klon: Branch, Commit, PR gegen testing
+cd ~/code/safe-my-plants
+git checkout -b chore/review-v2
+git add .github/workflows/mergeability.yml .github/workflows/pr-review.yml
+git commit -m "chore: kostenloses Merge-Gate + on-demand KI-Review (v2)"
+git push -u origin chore/review-v2
+gh pr create --base testing --title "chore: Review-Modell v2" \
+  --body "Kostenloses Gate + on-demand KI-Review (siehe project-templates Issue #62)"
+```
+
+### Verifikation am Pilot-PR (2–3 echte PRs)
+- [ ] Mergeability-Sticky-Kommentar erscheint und aktualisiert sich bei Push
+- [ ] Status `review-gate` grün (konfliktfrei) / rot (Konflikt)
+- [ ] **Kein** automatischer API-Call (kein `pr-review`-Lauf ohne Label)
+- [ ] Label `ai-review` setzen → beratender Haiku-Review erscheint, Gate unverändert
+- [ ] `/review` aus Claude Code (Pro/Max-Abo) postet Findings — ohne API-Kosten
+
+### Branch-Protection (falls nötig)
+`review-gate` muss als required Status-Check gelistet bleiben (Context-Name
+unverändert). Bei Web/React-Native-Repos ist er bereits in den Rulesets:
+```bash
+./scripts/apply-rulesets.sh --dry-run safe-my-plants   # prüfen
+```
+
+## Schritt 4 — Kern-Batch (nach erfolgreichem Piloten)
+Gleiches Muster, je eigener PR, klein → groß:
+```bash
+for r in 1x1_Trainer DrawFromMemory Pflanzkalender Epic_Calendar Eisenhauer; do
+  git clone "https://github.com/S540d/$r" ~/code/$r
+  ./scripts/migrate-to-v2.sh "S540d/$r" ~/code/$r
+  # dann pro Repo: Branch + Commit + PR gegen testing (siehe Schritt 3)
+done
+```
+Nach jedem Merge kurz einen realen PR gegenprüfen, bevor das nächste Repo folgt.
+
+## Schritt 5 — Abschluss
+- In jedem migrierten Repo: `ANTHROPIC_API_KEY` ist nur noch für den optionalen
+  `ai-review`-Fallback nötig — sonst entfernbar.
+- `@v1` in der Doku als deprecated markieren (README/AUTOMATION_SETUP nennen bereits `@v2`).
+- Issue #62 abhaken.
+
+## Rollback (falls etwas klemmt)
+- Pro Repo: PR schließen / Workflows entfernen → alter Zustand (`@v1`) bleibt nutzbar.
+- `v2`-Tag verschieben/löschen: `git push --delete origin v2`.
+- `main` wird nicht angefasst außer durch den bewussten PR-#61-Merge.

--- a/scripts/init-automation.sh
+++ b/scripts/init-automation.sh
@@ -87,6 +87,10 @@ else
 fi
 echo -e "${GREEN}  ✅ .github/workflows/ci-cd.yml${NC}"
 
+# Kostenloses Merge-Gate + Mergeability-Report (keine API-Kosten)
+cp "$TEMPLATE_DIR/automation-templates/mergeability.yml" .github/workflows/mergeability.yml
+echo -e "${GREEN}  ✅ .github/workflows/mergeability.yml${NC}"
+
 # PR Template
 cp "$TEMPLATE_DIR/automation-templates/PULL_REQUEST_TEMPLATE.md" .github/
 echo -e "${GREEN}  ✅ .github/PULL_REQUEST_TEMPLATE.md${NC}"

--- a/scripts/migrate-to-v2.sh
+++ b/scripts/migrate-to-v2.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# ─────────────────────────────────────────────────────────────────────────
+# migrate-to-v2.sh – Migriert ein Downstream-Repo auf das v2-Review-Modell:
+#   • kostenloses Merge-Gate via mergeability.yml (setzt review-gate, keine API-Kosten)
+#   • optionaler, beratender KI-Review via pr-review.yml (on-demand, Label "ai-review")
+#
+# Arbeitet auf einem LOKALEN Klon des Ziel-Repos (wie sync-standards.sh). Die
+# Workflow-Dateien werden hineinkopiert; Commit/PR machst du anschließend selbst
+# (gegen `testing`, nie direkt `main`).
+#
+# Usage:
+#   ./migrate-to-v2.sh [--dry-run] <owner/repo> </abs/pfad/zum/klon>
+#
+# Beispiel:
+#   ./migrate-to-v2.sh S540d/safe-my-plants ~/code/safe-my-plants
+# ─────────────────────────────────────────────────────────────────────────
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(dirname "$SCRIPT_DIR")"
+TPL_DIR="$ROOT_DIR/automation-templates"
+
+DRY_RUN=0
+ARGS=()
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run) DRY_RUN=1 ;;
+    -h|--help) grep -E '^#( |$)' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) ARGS+=("$arg") ;;
+  esac
+done
+
+REPO="${ARGS[0]:?owner/repo erforderlich, z.B. S540d/safe-my-plants}"
+CLONE="${ARGS[1]:?Pfad zum lokalen Klon erforderlich}"
+
+[ -d "$CLONE/.git" ] || { echo "❌ Kein Git-Klon: $CLONE"; exit 1; }
+[ -f "$TPL_DIR/mergeability.yml" ] || { echo "❌ Template fehlt: $TPL_DIR/mergeability.yml"; exit 1; }
+[ -f "$TPL_DIR/pr-review.yml" ]    || { echo "❌ Template fehlt: $TPL_DIR/pr-review.yml"; exit 1; }
+
+run() { if [ "$DRY_RUN" -eq 1 ]; then echo "   [dry-run] $*"; else "$@"; fi; }
+
+echo "→ Migration $REPO  (Klon: $CLONE)"
+
+# 1) Workflows einspielen.
+run mkdir -p "$CLONE/.github/workflows"
+run cp "$TPL_DIR/mergeability.yml" "$CLONE/.github/workflows/mergeability.yml"
+echo "   ✓ mergeability.yml (kostenloses Gate, @v2)"
+run cp "$TPL_DIR/pr-review.yml" "$CLONE/.github/workflows/pr-review.yml"
+echo "   ✓ pr-review.yml (optional, on-demand Label 'ai-review', @v2)"
+
+# 2) Labels setzen (idempotent; ergänzt 'ai-review').
+if command -v gh >/dev/null 2>&1 && gh auth status >/dev/null 2>&1; then
+  run "$SCRIPT_DIR/setup-labels.sh" "$REPO"
+  echo "   ✓ Labels gesetzt (inkl. 'ai-review')"
+else
+  echo "   ⚠️  gh nicht verfügbar/authentifiziert – Labels manuell: ./setup-labels.sh $REPO"
+fi
+
+cat <<NOTE
+
+✅ Dateien eingespielt$([ "$DRY_RUN" -eq 1 ] && echo " (dry-run – nichts geschrieben)").
+
+Nächste Schritte (im Klon $CLONE):
+  1. Feature-Branch + Commit + PR gegen 'testing':
+       git checkout -b chore/review-v2
+       git add .github/workflows/mergeability.yml .github/workflows/pr-review.yml
+       git commit -m "chore: kostenloses Merge-Gate + on-demand KI-Review (v2)"
+       git push -u origin chore/review-v2
+       gh pr create --base testing --title "chore: Review-Modell v2" --body "Kostenloses Gate + on-demand KI-Review"
+  2. Im PR prüfen: Mergeability-Kommentar erscheint, Status 'review-gate' wird gesetzt.
+  3. ANTHROPIC_API_KEY ist NUR noch für den optionalen 'ai-review'-Lauf nötig – sonst
+     entfernbar (Gate & /review-Abo brauchen ihn nicht).
+  4. Branch-Protection: sicherstellen, dass 'review-gate' als required Status-Check
+     gelistet ist (Context unverändert) – siehe scripts/apply-rulesets.sh.
+
+⚠️ Erst nachdem 'mergeability' im Repo einmal lief, 'review-gate' als required
+   aktiviert lassen – sonst wartet GitHub auf einen nie laufenden Check.
+NOTE

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -40,9 +40,12 @@ create_label "priority: low" "5fde5d" "Kann warten"
 create_label "blocked" "3d3d3d" "Blockiert - wartet auf etwas"
 create_label "ready-for-implementation" "34b13e" "Ready - kann angefangen werden"
 
-# PR-Review-Gate Labels (automatisch vom Claude-Review-Workflow gesetzt)
+# PR-Review-Gate Labels (vom Mergeability-Workflow / manuell genutzt)
 create_label "ready to merge" "0e8a16" "Review sauber/aufgelöst - Merge kann manuell erfolgen"
 create_label "needs human review" "d93f0b" "Findings brauchen menschliche Entscheidung - bitte prüfen"
+
+# Trigger-Label für den optionalen, metered KI-Review (pr-review.yml on-demand)
+create_label "ai-review" "5319e7" "Optionalen KI-Review (Anthropic API) für diesen PR anstoßen - kostet metered API"
 
 # Delete GitHub default labels (optional)
 echo ""


### PR DESCRIPTION
## Problem

`reusable-pr-review.yml` rief bei **jedem** PR-Event direkt die Anthropic-API (`curl`, Default Sonnet) — pro Token abgerechnet. Bei jedem Push entstanden erneut Kosten, die sich zu schnell summierten. Haiku würde nur die Kosten senken, nicht das metered Modell.

## Lösung: Drei-Schichten-Modell

**1. Kostenloses Gate — `reusable-mergeability.yml` (NEU, automatisch, keine API-Kosten)**
Läuft bei jedem PR, postet einen **Sticky-Kommentar** (Zielbranch-, Konflikt-Status, CI-Übersicht, Checkliste) und setzt den Status-Context **`review-gate`** rein über die GitHub-API:
- kein Merge-Konflikt → 🟢 grün
- Merge-Konflikt → 🔴 rot
- optional `block_on_protected_base: true` → blockt auch direkte PRs gegen `main`

**2. Tiefer KI-Review — `/review` aus Claude Code (primär, ohne Pay-per-Token)**
Gedeckt durch das Pro/Max-Abo, lokal am PC **oder** als Web-Session vom Telefon. Keine metered Kosten.

**3. Optionaler API-Fallback — Label `ai-review` (⚠️ metered)**
`reusable-pr-review.yml` ist jetzt **rein beratend** (kein Gate/keine Labels) und läuft nur on-demand via Label, Default Haiku.

## Warum das sicher ist
Der Status-Context bleibt **`review-gate`** — bestehende Branch-Protection-Rulesets (`github-ruleset-protect-main-web/react-native.json`) greifen unverändert, kein Ruleset-Edit nötig. `ANTHROPIC_API_KEY` ist nur noch für den optionalen Fallback erforderlich (kein Pflicht-Secret mehr).

## Geänderte Dateien
- **NEU**: `reusable-mergeability.yml`, `mergeability.yml` (Caller, lokal), `automation-templates/mergeability.yml` (Template `@v2`)
- `reusable-pr-review.yml` → beratend; Gate-/Label-Steps entfernt
- `pr-review.yml` (Caller + Template) → on-demand Label `ai-review`, Haiku
- Doku/Setup: `global-policy.md`, `AUTOMATION_SETUP.md`, `claude-commands/pr-review.md`, `LABELS.md`, `README.md`, `setup-labels.sh` (+`ai-review`), `init-automation.sh` (verteilt `mergeability.yml`)

## Verifikation
- [x] Alle Workflow-YAML parsen sauber
- [x] `jq`-Filter (Check-Übersicht, Konfliktzählung, Sticky-Marker) lokal mit Beispieldaten getestet (jq 1.7)
- [ ] Test-PR: Mergeability-Kommentar erscheint & aktualisiert sich, `review-gate` grün/rot, kein API-Call ohne Label, `ai-review`-Label triggert beratenden Review

## Rollout (nächste Schritte, separat)
`@v2`-Tag setzen → Pilot **safe-my-plants** → Kern-Batch (1x1_Trainer, DrawFromMemory, Pflanzkalender, Epic_Calendar, Eisenhauer). `@v1` bleibt eingefroren bis alle migriert sind.

https://claude.ai/code/session_01PuJuFsXQLw41Ry3fuiYbyf

---
_Generated by [Claude Code](https://claude.ai/code/session_01PuJuFsXQLw41Ry3fuiYbyf)_