### PR TITLE
chore: Sync-Restbereinigung nach #65 (testing == main)

### DIFF
--- a/automation-templates/pr-review.yml
+++ b/automation-templates/pr-review.yml
@@ -18,7 +18,6 @@ on:
 permissions:
   pull-requests: write
   contents: read
-  statuses: write
 
 jobs:
   pr-review:

--- a/scripts/setup-labels.sh
+++ b/scripts/setup-labels.sh
@@ -47,7 +47,6 @@ create_label "needs human review" "d93f0b" "Findings brauchen menschliche Entsch
 # Trigger-Label für den optionalen, metered KI-Review (pr-review.yml on-demand)
 create_label "ai-review" "5319e7" "Optionalen KI-Review (Anthropic API) für diesen PR anstoßen - kostet metered API"
 
-
 # Delete GitHub default labels (optional)
 echo ""
 echo "Removing GitHub default labels..."


### PR DESCRIPTION
Kleine Nachbereinigung zum Sync aus #65 (PR #66). Nach dem Squash-Merge unterschieden sich
nur noch 2 Dateien um je 1 Zeile von `main`; beides waren Reste, keine echten testing-only Fixes:

- `automation-templates/pr-review.yml`: überflüssiges `statuses: write` entfernt — der v2-Review
  ist rein beratend und setzt keinen Commit-Status. War ein Auto-Merge-Rest aus dem alten
  testing-Stand.
- `scripts/setup-labels.sh`: doppelte Leerzeile entfernt (Rest aus der Konfliktauflösung).

Danach ist `testing` inhaltlich **identisch** zu `main`.

Bezug: #65