### PR TITLE
chore: AAB-Archiv-Standard + Cache-Cleanup-Vorlage (#46)

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,36 @@
+name: Cache Cleanup
+
+# Löscht alte GitHub-Actions-Caches, damit das 10-GB-Repo-Limit nicht von
+# Build-Caches (node_modules, Gradle, Expo) vollläuft.
+# Läuft wöchentlich (So 03:00 UTC) oder manuell.
+on:
+  schedule:
+    - cron: "0 3 * * 0"
+  workflow_dispatch:
+
+permissions:
+  actions: write
+
+jobs:
+  cleanup:
+    name: 🧹 Clean Old Caches
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cleanup old caches
+        run: |
+          echo "Fetching cache list..."
+          gh extension install actions/gh-actions-cache || true
+
+          echo "Current cache usage:"
+          gh actions-cache list -R ${{ github.repository }} --limit 100 || true
+
+          echo "Deleting caches older than 7 days..."
+          gh actions-cache list -R ${{ github.repository }} --limit 100 | \
+            awk '{print $1}' | \
+            tail -n +2 | \
+            xargs -I {} gh actions-cache delete {} -R ${{ github.repository }} --confirm || true
+
+          echo "✅ Cache cleanup complete"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/dev-standards/base/global-policy.md
+++ b/dev-standards/base/global-policy.md
@@ -17,3 +17,8 @@
 - **Disk-Check vor EAS Build:** Skia-Libraries benötigen ~5–8 GB. Bei < 5 GB frei: `npm cache clean --force && rm -rf ~/.npm/_npx` (~13 GB, sicher löschbar)
 - **JAVA_HOME** für EAS/Expo-Builds explizit auf Android Studio JBR setzen: `export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"`
 - **Gradle-Lock nach Absturz:** Bei "Cannot lock file hash cache"-Fehler Daemons stoppen: `pkill -f GradleDaemon`, dann Workingdir leeren und neu starten
+- **AAB-Archiv:** Gebaute Release-AABs in einem **gitignored** `aab-archive/`-Verzeichnis im Repo-Root ablegen (in `.gitignore` aufnehmen – AABs sind 3–110 MB und gehören nie in die Git-History). Benennung: `<Projekt>-vX.Y.Z-vc<versionCode>-YYYY-MM-DD.aab`. **Retention: max. 2 Dateien** (aktuelles Release + ein Vorgänger für schnelles Rollback); ältere AABs löschen. Der Git-Tag `vX.Y.Z` ist die eigentliche Release-Baseline – ältere AABs lassen sich daraus jederzeit neu bauen.
+
+## [CI – CACHE-CLEANUP]
+
+- **Cache-Cleanup-Workflow** (`.github/workflows/cache-cleanup.yml`) in jedem Repo mit GitHub-Actions-Caches: löscht wöchentlich (So 03:00 UTC) bzw. on-demand alle Action-Caches älter als der jeweils letzte Lauf. GitHub-Limit ist 10 GB pro Repo – ohne Cleanup laufen Build-Caches (node_modules, Gradle, Expo) voll und verdrängen frische Einträge. Vorlage: `cache-cleanup.yml` in project-templates.


### PR DESCRIPTION
## Was

Setzt project-templates **#46** um (Cache-Cleanup in allen Repos) und legt die **AAB-Ablage** verbindlich in den dev-standards fest.

### dev-standards (`global-policy.md` → wird per Sync in alle CLAUDE.md gezogen)
- **AAB-Archiv:** gitignored `aab-archive/` im Repo-Root, Benennung `<Projekt>-vX.Y.Z-vc<vc>-YYYY-MM-DD.aab`, **Retention max. 2** (aktuell + 1 Vorgänger). Git-Tag ist die eigentliche Release-Baseline.
- **Neue Sektion `[CI – CACHE-CLEANUP]`:** Workflow in jedem Repo mit Actions-Caches (10-GB-Limit).

### Vorlage
- `.github/workflows/cache-cleanup.yml` aus Eisenhauer übernommen (wöchentlich So 03:00 UTC + `workflow_dispatch`).

## Warum #46
Cache-Nutzung gemessen: Eisenhauer **8,1 GB**, epic_Calendar **1,2 GB**, EPG **1,2 GB** – nahe am 10-GB-Limit. Antwort auf die Issue-Frage: **ja**, in allen aktiv gebauten Repos.

## Follow-up (separate PRs pro Repo)
- cache-cleanup.yml ausrollen: EPG, epic_Calendar, Pflanzkalender, 1x1_Trainer
- AAB-Ablage vereinheitlichen: EPG (Schwester-Ordner → `aab-archive/`), DrawFromMemory (`aab-archive/` gitignoren)

Closes #46