### PR TITLE
docs #69: quality-Gate Scope – welcher Test in welchem Repo

### DIFF
--- a/automation-templates/AUTOMATION_SETUP.md
+++ b/automation-templates/AUTOMATION_SETUP.md
@@ -314,6 +314,11 @@ blockiert den Merge **nicht**. Verbraucht Anthropic-API-Token — nur bewusst nu
 Schließt die Lücke des vorhandenen `reusable-ci-quality.yml`, das vorher keinen Caller hatte
 und damit nie automatisch ausgelöst wurde. Jetzt läuft lint + type-check + tests bei jedem PR.
 
+> **Nur in Repos mit Node-Projekt** (`package.json`). Reine Doku-/Template-Repos
+> (z. B. project-templates selbst) bekommen weder den Caller noch den required
+> Check `quality / quality` — ohne Lockfile schlägt `npm ci` immer fehl.
+> Siehe `dev-standards/global-policy.md` → „Required Status Checks pro Repo-Typ".
+
 ### Einrichtung pro Repo (Web oder React Native)
 
 1. Caller aus `automation-templates/` kopieren:

--- a/dev-standards/global-policy.md
+++ b/dev-standards/global-policy.md
@@ -30,7 +30,7 @@ gh pr create --base testing --title "Fix #XXX: ..." --body "..."
 - PRs immer gegen `testing`, nie direkt gegen `main`
 - Titel: Issue-Nummer referenzieren
 - CI/CD: Alle Checks müssen grün sein — **kein Merge bei CI-Fail**
-- **CI erzwingt lint/type-check/test bei jedem PR** (`ci-quality.yml`, required). Optionaler lokaler `pre-push` als schnelles Vorab-Feedback — kein Gate (umgehbar via `--no-verify`, nur auf explizite Bitte).
+- **CI erzwingt lint/type-check/test bei jedem PR** (`ci-quality.yml`, required in Node-Repos — siehe Tabelle „Required Status Checks pro Repo-Typ"). Optionaler lokaler `pre-push` als schnelles Vorab-Feedback — kein Gate (umgehbar via `--no-verify`, nur auf explizite Bitte).
 - Merge Feature → Testing: `gh pr merge <nr> --squash --delete-branch`
 - Merge Testing → Main: `gh pr merge <nr> --squash` (kein `--delete-branch`!)
 - Merge auf main braucht `--admin` (Branch Protection)
@@ -76,4 +76,20 @@ Du merged manuell, sobald CI grün und `review-gate` grün sind.
 `main` und `testing` sind in allen Repos per Ruleset geschützt:
 - Deletion blockiert
 - Non-fast-forward blockiert
-- Required Status Checks: `review-gate`, `mergeability / mergeability`, **`quality / quality`** (Issue #69)
+- Required Status Checks (siehe Tabelle unten)
+
+### Required Status Checks pro Repo-Typ (Issue #69)
+
+Der `quality / quality`-Check (lint + type-check + test via `reusable-ci-quality.yml`)
+ist **nur in Repos mit Node-Projekt** (`package.json`) verpflichtend. Reine
+Doku-/Template-Repos ohne `package.json` haben nichts zu linten/testen — dort
+würde der Check mangels Lockfile (`npm ci`) immer scheitern.
+
+| Repo-Typ | Beispiel | `review-gate` | `mergeability / mergeability` | `quality / quality` |
+|---|---|:---:|:---:|:---:|
+| **Node-App** (hat `package.json`) | EPG, Eisenhauer, 1x1_Trainer, DrawFromMemory, Pflanzkalender, safe_my_plants, CD-to-Spotify, epic_Calendar | ✅ required | ✅ required | ✅ **required** |
+| **Doku-/Template-Repo** (kein `package.json`) | project-templates | ✅ required | ✅ required | ❌ **nicht eintragen** |
+
+**Einrichtung in einem Node-Repo:**
+1. Caller kopieren: `automation-templates/ci-cd-{web,react-native}.yml` → `.github/workflows/ci-quality.yml`
+2. **Erst nach dem ersten erfolgreichen Lauf** `quality / quality` als required Status-Check ins Ruleset eintragen (sonst wartet GitHub auf einen nie laufenden Check).


### PR DESCRIPTION
## Kontext

Follow-up zu #70: Die Doku sagte pauschal „`quality / quality` required in allen Repos", aber **project-templates ist die Ausnahme** — kein `package.json`, also kein Lockfile, also `npm ci` immer rot. Genau das blockierte zuletzt den Merge von #70.

## Änderung

Klarstellung **welcher Check in welchem Repo verpflichtend** ist:

| Repo-Typ | `review-gate` | `mergeability` | `quality / quality` |
|---|:---:|:---:|:---:|
| Node-App (hat `package.json`) | ✅ | ✅ | ✅ **required** |
| Doku-/Template-Repo (kein `package.json`) | ✅ | ✅ | ❌ **nicht eintragen** |

- `dev-standards/global-policy.md`: neue Tabelle „Required Status Checks pro Repo-Typ" + Einrichtungs-Hinweis (Check erst nach erstem Lauf eintragen)
- `automation-templates/AUTOMATION_SETUP.md`: Gate-Abschnitt um „nur Node-Repos"-Hinweis ergänzt

Closes #69 (Doku-Teil)

🤖 Generated with [Claude Code](https://claude.com/claude-code)