### PR TITLE
fix #72: .claude/-Regel in global-policy.md auf #31-Stand korrigieren

### DIFF
--- a/dev-standards/global-policy.md
+++ b/dev-standards/global-policy.md
@@ -43,18 +43,23 @@ Alle Repos folgen diesem einheitlichen Schema:
 | Datei | Status | Zweck |
 |---|---|---|
 | `CLAUDE.md` (Root) | **committet** | Projektinstruktionen für Claude — öffentlich, versioniert |
-| `.claude/` | **gitignored** | Lokale Commands, Settings, Daten — nie committen |
+| `.claude/commands/` | **committet** | Geteilte Slash-Commands — versioniert (Issue #31) |
+| `.claude/settings.local.json`, `.claude/cache/`, `.claude/memory/` | **gitignored** | Maschinenspezifisch, lokal |
 
-### `.gitignore`-Pflichtzeile
+### `.gitignore`-Pflichtzeilen für Claude Code
 Jedes Repo muss in `.gitignore` enthalten:
 ```
-# Claude Code local files (commands, settings – never commit)
-.claude/
+# Claude Code – nur maschinenspezifische Artefakte ignorieren.
+# .claude/commands/ wird bewusst getrackt (Issue #31) → NICHT ignorieren.
+.claude/settings.local.json
+.claude/cache/
+.claude/memory/
 ```
 
 ### Warum
 - `CLAUDE.md` im Root wird von Claude Code automatisch gelesen und ist für alle Entwickler sichtbar
-- `.claude/` enthält lokale Commands und Settings, die gerätespezifisch sind und nicht ins Repo gehören
+- `.claude/commands/` enthält geteilte Slash-Commands, die für alle Entwickler im Repo gelten → versioniert (Issue #31)
+- Maschinenspezifische Artefakte (Settings, Cache, Memory) gehören nicht ins Repo
 
 ## PR-Review & Merge-Gate (kostenlos + abo-basiert)
 Die früher metered, pro PR laufende Anthropic-API ist abgelöst. Neues Modell:


### PR DESCRIPTION
## Problem
`global-policy.md` forderte pauschal `.claude/` als gitignored — das widerspricht der bewussten Entscheidung aus Issue #31, `.claude/commands/` zu versionieren (in allen App-Repos bereits so umgesetzt).

## Änderung
- **CLAUDE.md-Tabelle** differenziert: `commands/` = committet, maschinenspezifische Artefakte = gitignored
- **`.gitignore`-Pflichtzeilen** korrigiert: nicht mehr `.claude/` pauschal, sondern nur `.claude/settings.local.json`, `.claude/cache/`, `.claude/memory/`
- **Begründung** im „Warum"-Abschnitt ergänzt

Closes #72