### PR TITLE
fix #74: Ruleset-Konsolidierung über alle Repos

### DIFF
--- a/dev-standards/global-policy.md
+++ b/dev-standards/global-policy.md
@@ -83,6 +83,24 @@ Du merged manuell, sobald CI grün und `review-gate` grün sind.
 - Non-fast-forward blockiert
 - Required Status Checks (siehe Tabelle unten)
 
+### Soll-Struktur Rulesets (Issue #74)
+
+Jedes Repo hat genau **ein** aktives Ruleset `protect-main`, das beide Branches abdeckt.
+Weitere Rulesets nur bei bewusstem Bedarf:
+
+| Ruleset | Branches | Rules | Wer hat es |
+|---|---|---|---|
+| `protect-main` | `main` + `testing` | deletion, non_fast_forward, pull_request, required_status_checks | **alle Repos** |
+| `Main` (legacy) | `~DEFAULT_BRANCH` | pull_request approvals=1 + Admin-Bypass | EPG, Eisenhauer, 1x1_Trainer — **deaktiviert** (Issue #74); Approvals werden über protect-main geregelt wenn nötig |
+
+**Bewusst nicht vereinheitlicht / nicht vorhanden:**
+- Kein separates `protect-testing`-Ruleset — `protect-main` deckt `testing` bereits ab
+- Kein `Copilot review`-Ruleset — Copilot-Review wird nicht mehr genutzt (Issue #74)
+
+**Schutzgrad main vs. testing:**
+- `main`: `pull_request` ohne `dismiss_stale_reviews` + `review_gate` required → kein Merge bei Konflikt
+- `testing`: gleiche required checks, aber kein Approval nötig — bewusst weniger streng (Feature-Branches landen hier zuerst)
+
 ### Test-Ebenen (Issue #69)
 
 Tests laufen auf zwei Ebenen. **Leitprinzip:** Was als kostenloser Workflow ohne
@@ -98,14 +116,16 @@ umgehbar. Alles Weitere läuft **lokal „in der Regel"** (Komfort, kein Gate).
 | `mergeability / mergeability` | Mergeability-Report | nein | **alle Repos** |
 | `security-scan / security-scan` | Hardcoded Keys/Tokens + getrackte Secrets | nein | **alle Repos** |
 | `gitignore-audit / gitignore-audit` | `.gitignore`-Pflichteinträge + keine Secrets getrackt | nein | **alle Repos** |
-| `quality / quality` | lint + type-check + test | **ja** | **nur Node-Repos** (Ausnahme: project-templates) |
+| `🔍 Code Quality & Linting` (EPG, Eisenhauer, 1x1_Trainer, DrawFromMemory, Pflanzkalender, CD-to-Spotify, epic_Calendar) oder `lint-and-typecheck` (safe-my-plants) | lint + type-check + test | **ja** | **nur Node-Repos** (Ausnahme: project-templates) |
 
-> **Begründete Abweichung:** `quality / quality` braucht `package.json`/Lockfile.
+> **Begründete Abweichung:** Der Quality-Check braucht `package.json`/Lockfile.
 > In reinen Doku-/Template-Repos (project-templates) würde `npm ci` immer scheitern
 > → dort **nicht** eintragen. Alle anderen Gates gelten ausnahmslos überall.
+> Der Check-Context-Name entspricht dem tatsächlichen Job-Namen im jeweiligen `ci-cd.yml`
+> (nicht `quality / quality` aus `reusable-ci-quality.yml` — wird nicht genutzt).
 
 **Node-Repos:** EPG, Eisenhauer, 1x1_Trainer, DrawFromMemory, Pflanzkalender,
-safe_my_plants, CD-to-Spotify, epic_Calendar.
+safe-my-plants, CD-to-Spotify-PWA, epic_Calendar.
 
 #### Ebene B — lokal „in der Regel" (optional, kein Gate)
 

--- a/dev-standards/global-policy.md
+++ b/dev-standards/global-policy.md
@@ -43,18 +43,23 @@ Alle Repos folgen diesem einheitlichen Schema:
 | Datei | Status | Zweck |
 |---|---|---|
 | `CLAUDE.md` (Root) | **committet** | Projektinstruktionen für Claude — öffentlich, versioniert |
-| `.claude/` | **gitignored** | Lokale Commands, Settings, Daten — nie committen |
+| `.claude/commands/` | **committet** | Geteilte Slash-Commands — versioniert (Issue #31) |
+| `.claude/settings.local.json`, `.claude/cache/`, `.claude/memory/` | **gitignored** | Maschinenspezifisch, lokal |
 
-### `.gitignore`-Pflichtzeile
+### `.gitignore`-Pflichtzeilen für Claude Code
 Jedes Repo muss in `.gitignore` enthalten:
 ```
-# Claude Code local files (commands, settings – never commit)
-.claude/
+# Claude Code – nur maschinenspezifische Artefakte ignorieren.
+# .claude/commands/ wird bewusst getrackt (Issue #31) → NICHT ignorieren.
+.claude/settings.local.json
+.claude/cache/
+.claude/memory/
 ```
 
 ### Warum
 - `CLAUDE.md` im Root wird von Claude Code automatisch gelesen und ist für alle Entwickler sichtbar
-- `.claude/` enthält lokale Commands und Settings, die gerätespezifisch sind und nicht ins Repo gehören
+- `.claude/commands/` enthält geteilte Slash-Commands, die für alle Entwickler im Repo gelten → versioniert (Issue #31)
+- Maschinenspezifische Artefakte (Settings, Cache, Memory) gehören nicht ins Repo
 
 ## PR-Review & Merge-Gate (kostenlos + abo-basiert)
 Die früher metered, pro PR laufende Anthropic-API ist abgelöst. Neues Modell:


### PR DESCRIPTION
## Was wurde gemacht

### GitHub-Rulesets (direkt via API, kein Code-Change)
- **4 `protect-testing`-Rulesets gelöscht** (EPG, Pflanzkalender, safe-my-plants, epic_Calendar) — `protect-main` deckt `testing` bereits ab, reines Duplikat
- **4 alte `Main`/`Copilot`-Rulesets deaktiviert** (EPG: Copilot + Main, Eisenhauer: Main, 1x1_Trainer: Main) — veraltet, Copilot nicht mehr genutzt
- **1x1_Trainer:** `quality / quality` aus `protect-main` entfernt (war Altlast aus früherem Test)
- **CD-to-Spotify:** `code-quality` → `mergeability / mergeability` (v1-Überbleibsel ersetzt)

### Dokumentation (`global-policy.md`)
- Neue Sektion „Soll-Struktur Rulesets": ein `protect-main` pro Repo, beide Branches, kein separates `protect-testing`
- Ebene-A-Tabelle: korrekten Quality-Check-Context dokumentiert (`🔍 Code Quality & Linting` / `lint-and-typecheck`), nicht den nie genutzten `quality / quality`

Closes #74