### PR TITLE
docs: Branch-Cleanup-Regel — main/testing nie löschen

### DIFF
--- a/dev-standards/base/global-policy.md
+++ b/dev-standards/base/global-policy.md
@@ -6,6 +6,7 @@
 - PRs immer gegen `testing`, nie direkt gegen `staging` oder `main`
 - Merge auf `main` nur mit expliziter schriftlicher Freigabe
 - `--delete-branch` nur für Feature-Branches (nie staging/testing)
+- **Lokales Branch-Cleanup:** `main` und `testing` NIE löschen — auch nicht beim Bulk-Delete verwaister `[gone]`-Branches. Ein fehlender `origin/main`/`origin/testing` ist ein **wiederherzustellender Defekt** (lokal behalten, nach origin zurückpushen), kein Aufräum-Signal.
 - `--no-verify` nur auf explizite Bitte
 - **Vor jedem Push: lokale Tests ausführen** (`npm test` bzw. projektspezifischer Test-Befehl) – kein Push ohne grüne lokale Tests
 - **Kein Merge bei CI-Fail** – Branch Protection erzwingt das technisch; nie mit `--admin` umgehen außer auf explizite Bitte

--- a/dev-standards/global-policy.md
+++ b/dev-standards/global-policy.md
@@ -36,6 +36,10 @@ gh pr create --base testing --title "Fix #XXX: ..." --body "..."
 - Merge auf main braucht `--admin` (Branch Protection)
 - `--no-verify` und `--admin` nur auf explizite Bitte
 
+### Lokales Branch-Cleanup
+- Verwaiste Feature-Branches (Upstream `[gone]`, PR gemergt+remote gelöscht) dürfen pauschal lokal gelöscht werden (`git branch -D`).
+- **Ausnahme: `main` und `testing` NIE löschen** — auch nicht, wenn ihr Upstream `[gone]` ist. Ein fehlender `origin/main`/`origin/testing` ist ein **wiederherzustellender Defekt**: lokalen Branch behalten und nach origin zurückpushen (testing dabei sinnvoll mit main aktualisieren, sodass testing ≥ main).
+
 ## CLAUDE.md Standard
 
 Alle Repos folgen diesem einheitlichen Schema:


### PR DESCRIPTION
Ergänzt die [GLOBAL POLICY] um eine Regel zum lokalen Branch-Cleanup.

## Hintergrund
Bei einer Sync-Session über alle Repos wurde beim pauschalen Löschen verwaister `[gone]`-Branches (`git branch -D`) versehentlich der lokale `testing`-Branch von Pflanzkalender mitgelöscht — sein `origin/testing` war ebenfalls `[gone]`. Das musste manuell wiederhergestellt und nach origin gepusht werden.

## Regel
`main` und `testing` dürfen beim Bulk-Cleanup **nie** gelöscht werden, auch nicht bei `[gone]`-Upstream. Ein fehlender `origin/main`/`origin/testing` ist ein wiederherzustellender Defekt, kein Aufräum-Signal.

Eingetragen in beide Quellen:
- `dev-standards/base/global-policy.md` (an alle Repos auto-synchronisiert)
- `dev-standards/global-policy.md` (Referenzdokument, neue Sektion „Lokales Branch-Cleanup")